### PR TITLE
Fix for EntityRecognizer parseBoolean

### DIFF
--- a/Node/lib/dialogs/EntityRecognizer.js
+++ b/Node/lib/dialogs/EntityRecognizer.js
@@ -1,3 +1,4 @@
+"use strict";
 var utils = require('../utils');
 var chrono = require('chrono-node');
 var EntityRecognizer = (function () {
@@ -193,9 +194,9 @@ var EntityRecognizer = (function () {
         }
     };
     EntityRecognizer.dateExp = /^\d{4}-\d{2}-\d{2}/i;
-    EntityRecognizer.yesExp = /^(1|y|yes|yep|sure|ok|true)\z/i;
-    EntityRecognizer.noExp = /^(0|n|no|nope|not|false)\z/i;
+    EntityRecognizer.yesExp = /^(1|y|yes|yep|sure|ok|true)$/i;
+    EntityRecognizer.noExp = /^(0|n|no|nope|not|false)$/i;
     EntityRecognizer.numberExp = /[+-]?(?:\d+\.?\d*|\d*\.?\d+)/;
     return EntityRecognizer;
-})();
+}());
 exports.EntityRecognizer = EntityRecognizer;

--- a/Node/src/dialogs/EntityRecognizer.ts
+++ b/Node/src/dialogs/EntityRecognizer.ts
@@ -62,8 +62,8 @@ export interface IFindMatchResult {
 
 export class EntityRecognizer {
     static dateExp = /^\d{4}-\d{2}-\d{2}/i;
-    static yesExp = /^(1|y|yes|yep|sure|ok|true)\z/i;
-    static noExp = /^(0|n|no|nope|not|false)\z/i;
+    static yesExp = /^(1|y|yes|yep|sure|ok|true)$/i;
+    static noExp = /^(0|n|no|nope|not|false)$/i;
     static numberExp = /[+-]?(?:\d+\.?\d*|\d*\.?\d+)/;
 
     static findEntity(entities: IEntity[], type: string): IEntity {

--- a/Node/tests/EntityRecognizer.js
+++ b/Node/tests/EntityRecognizer.js
@@ -1,0 +1,55 @@
+var assert = require('assert');
+var builder = require('../');
+
+var yesTokens = '1|y|yes|yep|sure|ok|true'.split('|');
+var noTokens = '0|n|no|nope|not|false'.split('|');
+
+function createPaddedUtterance(utterance) {
+    return [
+        utterance,
+        ' ' + utterance,
+        utterance + ' ',
+        ' ' + utterance + ' '
+    ];
+}
+
+function createPaddedUtterances(utterances) {
+    return [].concat.apply(
+        [], 
+        utterances.map(createPaddedUtterance));
+}
+
+describe('EntityRecognizer', function() {
+    describe('parseBoolean', function() {
+        it('should return true', function() {
+            var utterances = createPaddedUtterances(yesTokens);
+            
+            utterances.forEach(function(u) {
+                assert(builder.EntityRecognizer.parseBoolean(u) === true, 'utterance: ' + u);
+            });
+        });
+        
+        it('should return false', function() {        
+            var utterances = createPaddedUtterances(noTokens);
+            
+            utterances.forEach(function(u) {
+                assert(builder.EntityRecognizer.parseBoolean(u) === false, 'utterance: ' + u);
+            });
+        });
+        
+        it ('should return undefined', function() {                
+            var utterances = createPaddedUtterances([
+                'no I dont think so',
+                'yes lets do it',
+                'no thankyou',
+                'yes please',
+                'yesno',
+                'yes no'
+            ]);
+            
+            utterances.forEach(function(u) {
+                assert(builder.EntityRecognizer.parseBoolean(u) === undefined, 'utterance: ' + u);
+            });
+        });
+    });
+});


### PR DESCRIPTION
- yesExp and noExp regexes used incorrect "\z" character to denote end of line anchor, in JavaScript they should use "$"
- consequence of this was that Prompts.confirm would always report undefined
- added EntityRecognizer test with parseBoolean tests