### PR TITLE
PromptConfirm TryParse should ignore casing on message

### DIFF
--- a/CSharp/Library/Dialogs/PromptDialog.cs
+++ b/CSharp/Library/Dialogs/PromptDialog.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             protected override bool TryParse(Message message, out bool result)
             {
-                switch (message.Text)
+                switch (message.Text.Trim().ToLower())
                 {
                     case "y":
                     case "yes":


### PR DESCRIPTION
When replying to a PromptConfirm, the logic does not properly interpret answers that are not lower-cased.  It is common for smart phones to "autocorrect" response casing so the bug is quite noticeable when interacting with a bot through a smartphone.