### PR TITLE
Fix url encode of text when language is french

### DIFF
--- a/CSharp/Library/Luis/LuisService.cs
+++ b/CSharp/Library/Luis/LuisService.cs
@@ -86,13 +86,12 @@ namespace Microsoft.Bot.Builder.Luis
 
         Uri ILuisService.BuildUri(string text)
         {
-            var queryString = HttpUtility.ParseQueryString(string.Empty);
-            queryString["id"] = this.model.ModelID;
-            queryString["subscription-key"] = this.model.SubscriptionKey;
-            queryString["q"] = text;
+            var modelId = HttpUtility.UrlEncode(this.model.ModelID);
+            var subscriptionKey = HttpUtility.UrlEncode(this.model.SubscriptionKey);
+            var q = HttpUtility.UrlEncode(text);
 
             var builder = new UriBuilder(UriBase);
-            builder.Query = queryString.ToString();
+            builder.Query = $"id={modelId}&subscription-key={subscriptionKey}&q={q}";
             return builder.Uri;
         }
 


### PR DESCRIPTION
I have make tests with french language. Accents are correct in LUIS when use UrlEncode().

Example : q=dis moi si je possède lanfeust de troy ?