### PR TITLE
Fix capitalization in reference to `consts.ts`

### DIFF
--- a/Node/src/Session.ts
+++ b/Node/src/Session.ts
@@ -33,7 +33,7 @@
 
 import collection = require('./dialogs/DialogCollection');
 import dialog = require('./dialogs/Dialog');
-import consts = require('./Consts');
+import consts = require('./consts');
 import sprintf = require('sprintf-js');
 import events = require('events');
 


### PR DESCRIPTION
This matters on case-sensitive filesystems---that is, it arises on Linux but generally doesn't come up on Windows or OS X. On ext4 and othercase-sensitive filesystems, Node can't find `consts.ts` when it is referenced as `Consts`.

In particular, I got this error when running a bot on Linux:

```
module.js:341
    throw err;
    ^

Error: Cannot find module '../Consts'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.Module._load (module.js:290:25)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at Object.<anonymous> ([snip]/node_modules/botbuilder/lib/dialogs/DialogCollection.js:10:14)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
```