### PR TITLE
Changed Math.round to Math.floor to fetch random array element

### DIFF
--- a/Node/src/Message.ts
+++ b/Node/src/Message.ts
@@ -79,7 +79,7 @@ export class Message implements IMessage {
     }
     
     static randomPrompt(prompts: string[]): string {
-        var i = Math.round(Math.random() * prompts.length);
+        var i = Math.floor(Math.random() * prompts.length);
         return prompts[i];
     }
     


### PR DESCRIPTION
Nice feature introduced in 0.9.0. Just tested this and got an "undefined" as bot reply. Found this cause.