### PR TITLE
message.setText("string") did not work

### DIFF
--- a/Node/src/Message.ts
+++ b/Node/src/Message.ts
@@ -45,7 +45,7 @@ export class Message implements IMessage {
     public setText(ses: session.Session, prompts: string[], ...args: any[]): this;
     public setText(ses: session.Session, prompts: any, ...args: any[]): this {
         var m = <IMessage>this;
-        var msg: string = typeof prompts == 'string' ? msg : Message.randomPrompt(prompts);
+        var msg: string = typeof (msg || prompts) == 'string' ? (msg || prompts) : Message.randomPrompt(prompts);
         args.unshift(msg);
         m.text = session.Session.prototype.gettext.apply(ses, args);
         return this;


### PR DESCRIPTION
The parameters "msg" and "prompts" might be a string, so this is considered now. Before, prompts seemed to be undefined even while msg was defined, so m.text was set to undefined. Not sure if this solution is the best.