### PR TITLE
Remove deprecation warning in expressjs

### DIFF
--- a/Node/lib/bots/BotConnectorBot.js
+++ b/Node/lib/bots/BotConnectorBot.js
@@ -157,7 +157,7 @@ var BotConnectorBot = (function (_super) {
                         }
                         if (res) {
                             _this.emit('reply', reply);
-                            res.send(200, reply);
+                            res.status(200).send(reply);
                             res = null;
                         }
                         else if (ses.message.conversationId) {


### PR DESCRIPTION
`res.send(status, body)` is deprecated in expressjs, replaced it with `res.status(status).send(body)`