### PR TITLE
Fix restify API

### DIFF
--- a/Node/lib/bots/BotConnectorBot.js
+++ b/Node/lib/bots/BotConnectorBot.js
@@ -157,7 +157,8 @@ var BotConnectorBot = (function (_super) {
                         }
                         if (res) {
                             _this.emit('reply', reply);
-                            res.status(200).send(reply);
+                            res.status(200)
+                            res.send(reply);
                             res = null;
                         }
                         else if (ses.message.conversationId) {


### PR DESCRIPTION
In call to `res.status(200)` response returns statusCode (200) instead of response object (this), so there is no chaining.