### PR TITLE
Fixed issue #509.

### DIFF
--- a/CSharp/Samples/SimpleAlarmBot/SimpleAlarmDialog.cs
+++ b/CSharp/Samples/SimpleAlarmBot/SimpleAlarmDialog.cs
@@ -202,7 +202,11 @@ namespace Microsoft.Bot.Sample.SimpleAlarmBot
             context.Wait(MessageReceived);
         }
 
-        public SimpleAlarmDialog(ILuisService service = null)
+        public SimpleAlarmDialog()
+        {
+
+        }
+        public SimpleAlarmDialog(ILuisService service)
             : base(service)
         {
         }


### PR DESCRIPTION
Issue #509 . 
The problem was making ILuisService optional and passing null as default value. LuisDialog now accepts params ILuisService[] services which was taking null as first item of the array resulting in NullReferenceException. Refer to my comment on the issue.
Fixed this by adding a default constructor and removed the default null assignment from other constructor.