### PR TITLE
Updated app.js to match IMiddlewareMap hook. Issue: #628

### DIFF
--- a/Node/examples/basics-logging/app.js
+++ b/Node/examples/basics-logging/app.js
@@ -20,7 +20,7 @@ bot.dialog('/', function (session) {
 
 // Install logging middleware
 bot.use({
-    dialog: function (session, next) {
+    botbuilder: function (session, next) {
         if (/^\/log on/i.test(session.message.text)) {
             session.userData.isLogging = true;
             session.send('Logging is now turned on');


### PR DESCRIPTION
This is a pull request for Issue [628](https://github.com/Microsoft/BotBuilder/issues/628)

The original app.js bot.use had "dialog" as the middleware hook in the example usage of "bot.use". According to IMiddlewareMap's definition "dialog" is not a valid hook and thus causes the "Logging" section to never run.

The function defined for "dialog" has "session" and "next" as parameters which corresponds to IMiddlewareMap's "botbuilder" hook.

I updated app.js to change "dialog" to "botbuilder".

The example app.js now runs without error and outputs the logging messages.