### PR TITLE
allow additional logging through NODE_DEBUG #716

### DIFF
--- a/Node/core/lib/logger.js
+++ b/Node/core/lib/logger.js
@@ -1,7 +1,9 @@
+"use strict";
 var sprintf = require('sprintf-js');
 var Channel = require('./Channel');
 var consts = require('./consts');
 var prompts = require('./dialogs/Prompts');
+var debugLoggingEnabled = new RegExp('\\bbotbuilder\\b', 'i').test(process.env.NODE_DEBUG || '');
 function error(fmt) {
     var args = [];
     for (var _i = 1; _i < arguments.length; _i++) {
@@ -27,12 +29,10 @@ function info(addressable, fmt) {
         args[_i - 2] = arguments[_i];
     }
     var channelId = Channel.getChannelId(addressable);
-    switch (channelId) {
-        case Channel.channels.emulator:
-            var prefix = getPrefix(addressable);
-            var msg = args.length > 0 ? sprintf.vsprintf(fmt, args) : fmt;
-            console.info(prefix + msg);
-            break;
+    if (channelId === Channel.channels.emulator || debugLoggingEnabled) {
+        var prefix = getPrefix(addressable);
+        var msg = args.length > 0 ? sprintf.vsprintf(fmt, args) : fmt;
+        console.info(prefix + msg);
     }
 }
 exports.info = info;

--- a/Node/core/src/logger.ts
+++ b/Node/core/src/logger.ts
@@ -37,6 +37,8 @@ import ses = require('./Session');
 import consts = require('./consts');
 import prompts = require('./dialogs/Prompts');
 
+const debugLoggingEnabled = new RegExp('\\bbotbuilder\\b', 'i').test(process.env.NODE_DEBUG || '');
+
 export function error(fmt: string, ...args: any[]): void {
     var msg = args.length > 0 ? sprintf.vsprintf(fmt, args) : fmt;
     console.error('ERROR: ' + msg);
@@ -50,13 +52,11 @@ export function warn(addressable: ses.Session|IMessage|IAddress, fmt: string, ..
 
 export function info(addressable: ses.Session|IMessage|IAddress, fmt: string, ...args: any[]): void {
     var channelId = Channel.getChannelId(addressable);
-    switch (channelId) {
-        case Channel.channels.emulator:
-            var prefix = getPrefix(<ses.Session>addressable);
-            var msg = args.length > 0 ? sprintf.vsprintf(fmt, args) : fmt;
-            console.info(prefix + msg);
-            break;
-    }    
+    if (channelId === Channel.channels.emulator || debugLoggingEnabled){
+        var prefix = getPrefix(<ses.Session>addressable);
+        var msg = args.length > 0 ? sprintf.vsprintf(fmt, args) : fmt;
+        console.info(prefix + msg);
+    }
 }
 
 function getPrefix(addressable: ses.Session): string {


### PR DESCRIPTION

Example of the output one will get when having `"NODE_DEBUG" : "botbuilder"`
```
ChatConnector: message received.
Message Received:  yeh
..Prompts.text - session.endDialogWithResult()
result: yeh
./address - session.sendBatch() sending 0 messages
{ faulted: true,
  success: 0,
  errors: [ { request: 'yeh', index: 0, reason: 'Not Found' } ] }
./address - session.send()
./address - session.beginDialog(BotBuilder:Prompts)
..Prompts.text - session.send()
..Prompts.text - session.sendBatch() sending 2 messages
ChatConnector: sending message.
ChatConnector: sending message.
```
or 
```
session.beginDialog(/)
/ - waterfall() step 0 of 11
/ - session.send()
/ - waterfall() step 1 of 11
/ - waterfall() step 2 of 11
/ - waterfall() step 3 of 11
/ - session.send()
/ - session.beginDialog(/address)
./address - session.beginDialog(BotBuilder:Prompts)
..Prompts.text - session.send()
..Prompts.text - session.sendBatch() sending 3 messages
```


Regarding code, not sure why `logger.js` got the `"use strict";` part. 
Appreciate any feedback on the code changes