### PR TITLE
Include ChannelId when creating replay message.

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Connector/ActivityEx.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector/ActivityEx.cs
@@ -35,13 +35,14 @@ namespace Microsoft.Bot.Connector
             reply.From = this.Recipient;
             reply.Recipient = this.From;
             reply.ReplyToId = this.Id;
+            reply.ChannelId = this.ChannelId;
             reply.Conversation = this.Conversation;
             reply.Conversation.IsGroup = null; // don't need to send in a reply
             reply.Text = text ?? String.Empty;
             reply.Locale = locale ?? this.Locale;
             return reply;
         }
-                
+
         public static IMessageActivity CreateMessageActivity() { return new Activity(ActivityTypes.Message); }
 
         public static IContactRelationUpdateActivity CreateContactRelationUpdateActivity() { return new Activity(ActivityTypes.ContactRelationUpdate); }

--- a/CSharp/Library/Microsoft.Bot.Connector/ActivityEx.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector/ActivityEx.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Bot.Connector
             reply.From = this.Recipient;
             reply.Recipient = this.From;
             reply.ReplyToId = this.Id;
+            reply.ServiceUrl = this.ServiceUrl;
             reply.ChannelId = this.ChannelId;
             reply.Conversation = this.Conversation;
             reply.Conversation.IsGroup = null; // don't need to send in a reply

--- a/CSharp/Samples/GraphBot/Microsoft.Bot.Sample.GraphBot/project.fragment.lock.json
+++ b/CSharp/Samples/GraphBot/Microsoft.Bot.Sample.GraphBot/project.fragment.lock.json
@@ -5,7 +5,7 @@
       "type": "project",
       "framework": ".NETFramework,Version=v4.6",
       "compile": {
-        "bin/Debug/Microsoft.Bot.Builder.dll": {}
+        "bin/Release/Microsoft.Bot.Builder.dll": {}
       },
       "runtime": {
         "../packages/Autofac.3.5.2/lib/net40/Autofac.dll": {},
@@ -15,14 +15,21 @@
         "../packages/Microsoft.Rest.ClientRuntime.1.8.2/lib/net45/Microsoft.Rest.ClientRuntime.dll": {},
         "../packages/Microsoft.WindowsAzure.ConfigurationManager.3.2.1/lib/net40/Microsoft.WindowsAzure.Configuration.dll": {},
         "../packages/Newtonsoft.Json.8.0.3/lib/net45/Newtonsoft.Json.dll": {},
-        "bin/Debug/Microsoft.Bot.Builder.dll": {}
+        "bin/Release/Microsoft.Bot.Builder.dll": {}
+      },
+      "contentFiles": {
+        "bin/Release/Microsoft.Bot.Builder.pdb": {
+          "buildAction": "None",
+          "codeLanguage": "any",
+          "copyToOutput": true
+        }
       }
     },
     "Microsoft.Bot.Connector/1.0.0": {
       "type": "project",
       "framework": ".NETFramework,Version=v4.5",
       "compile": {
-        "bin/Debug/Microsoft.Bot.Connector.dll": {}
+        "bin/Release/Microsoft.Bot.Connector.dll": {}
       },
       "runtime": {
         "../../packages/Microsoft.AspNet.WebApi.Client.5.2.3/lib/net45/System.Net.Http.Formatting.dll": {},
@@ -31,7 +38,14 @@
         "../../packages/Microsoft.Rest.ClientRuntime.1.8.2/lib/net45/Microsoft.Rest.ClientRuntime.dll": {},
         "../../packages/Newtonsoft.Json.8.0.3/lib/net45/Newtonsoft.Json.dll": {},
         "../../packages/System.IdentityModel.Tokens.Jwt.4.0.2.206221351/lib/net45/System.IdentityModel.Tokens.Jwt.dll": {},
-        "bin/Debug/Microsoft.Bot.Connector.dll": {}
+        "bin/Release/Microsoft.Bot.Connector.dll": {}
+      },
+      "contentFiles": {
+        "bin/Release/Microsoft.Bot.Connector.pdb": {
+          "buildAction": "None",
+          "codeLanguage": "any",
+          "copyToOutput": true
+        }
       }
     }
   }


### PR DESCRIPTION
ChannelId was not copied when creating replay message. 
Channel Id can be used in dialogs to modify the answer to better use each channel features.
The service URL was also missing.