### PR TITLE
Fix Demo Skype Example

### DIFF
--- a/Node/examples/demo-skype/app.js
+++ b/Node/examples/demo-skype/app.js
@@ -401,7 +401,7 @@ bot.dialog('/signin', [
         var msg = new builder.Message(session) 
             .attachments([ 
                 new builder.SigninCard(session) 
-                    .title("You must first signin to your account.") 
+                    .text("You must first signin to your account.") 
                     .button("signin", "http://example.com/") 
             ]); 
         session.endDialog(msg); 


### PR DESCRIPTION
SigninCard does not have a `title` function instead should be `text` according to the latest code

https://docs.botframework.com/en-us/node/builder/chat-reference/classes/_botbuilder_d_.signincard.html 