### PR TITLE
Support call webhook query parameters

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder.Calling/CallingContext.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Calling/CallingContext.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Bot.Builder.Internals.Fibers;
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -27,6 +28,11 @@ namespace Microsoft.Bot.Builder.Calling
         /// The calling request content.
         /// </summary>
         public string Content { set; get; }
+
+        /// <summary>
+        /// The calling request query parameters
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, string>> QueryParameters { set; get; }
         
         /// <summary>
         /// The additional data when calling request has multipart content. 
@@ -122,7 +128,8 @@ namespace Microsoft.Bot.Builder.Calling
                 }
 
                 var content = await Request.Content.ReadAsStringAsync().ConfigureAwait(false);
-                return GenerateParsedResults(HttpStatusCode.OK, content);                
+                IEnumerable<KeyValuePair<string, string>> queryParameters = Request.GetQueryNameValuePairs();
+                return GenerateParsedResults(HttpStatusCode.OK, content, null, queryParameters);                
             }
             catch (Exception e)
             {
@@ -154,14 +161,15 @@ namespace Microsoft.Bot.Builder.Calling
                 return GenerateParsedResults(HttpStatusCode.InternalServerError);
             }
         }
-        
-        private ParsedCallingRequest GenerateParsedResults(HttpStatusCode statusCode, string content = null, Task<Stream> additionalData = null)
+
+        private ParsedCallingRequest GenerateParsedResults(HttpStatusCode statusCode, string content = null, Task<Stream> additionalData = null, IEnumerable<KeyValuePair<string, string>> queryParameters = null)
         {
             return new ParsedCallingRequest
             {
                 Content = content,
                 ParseStatusCode = statusCode, 
-                AdditionalData = additionalData
+                AdditionalData = additionalData,
+                QueryParameters = queryParameters
             };
         }
 

--- a/CSharp/Library/Microsoft.Bot.Builder.Calling/CallingConversation.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Calling/CallingConversation.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Bot.Builder.Calling
                         switch (callRequestType)
                         {
                             case CallRequestType.IncomingCall:
-                                res = await bot.CallingBotService.ProcessIncomingCallAsync(parsedRequest.Content);
+                                res = await bot.CallingBotService.ProcessIncomingCallAsync(parsedRequest.Content, parsedRequest.QueryParameters);
                                 break;
                             case CallRequestType.CallingEvent:
                                 res = await bot.CallingBotService.ProcessCallbackAsync(parsedRequest.Content, parsedRequest.AdditionalData);

--- a/CSharp/Library/Microsoft.Bot.Builder.Calling/Events/IncomingCallEvent.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Calling/Events/IncomingCallEvent.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 
 using Microsoft.Bot.Builder.Calling.ObjectModel.Contracts;
+using System.Collections.Specialized;
+using System.Collections.Generic;
 
 namespace Microsoft.Bot.Builder.Calling.Events
 {
     public class IncomingCallEvent
     {
-        public IncomingCallEvent(Conversation conversation, Workflow resultingWorkflow)
+        public IncomingCallEvent(Conversation conversation, Workflow resultingWorkflow, IEnumerable<KeyValuePair<string, string>> callParameters = null)
         {
             if (conversation == null)
                 throw new ArgumentNullException(nameof(conversation));
@@ -14,10 +16,12 @@ namespace Microsoft.Bot.Builder.Calling.Events
                 throw new ArgumentNullException(nameof(resultingWorkflow));
             IncomingCall = conversation;
             ResultingWorkflow = resultingWorkflow;
+            IncomingCallParameters = callParameters ?? new Dictionary<string, string>();
         }
 
         public Conversation IncomingCall { get; set; }
 
         public Workflow ResultingWorkflow { get; set; }
+        public IEnumerable<KeyValuePair<string, string>> IncomingCallParameters { get; set; }
     }
 }

--- a/CSharp/Library/Microsoft.Bot.Builder.Calling/ICallingBotService.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Calling/ICallingBotService.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading.Tasks;
 
 using Microsoft.Bot.Builder.Calling.Events;
+using System.Collections.Generic;
 
 namespace Microsoft.Bot.Builder.Calling
 {
@@ -75,7 +76,23 @@ namespace Microsoft.Bot.Builder.Calling
         /// Method responsible for processing the data sent with POST request to incoming call URL
         /// </summary>
         /// <param name="content">The content of request</param>
+        /// <param name="queryParameters">The query parameters of request</param>
+        /// <returns>Returns the response that should be sent to the sender of POST request</returns>
+        string ProcessIncomingCall(string content, IEnumerable<KeyValuePair<string, string>> queryParameters);
+
+        /// <summary>
+        /// Method responsible for processing the data sent with POST request to incoming call URL
+        /// </summary>
+        /// <param name="content">The content of request</param>
         /// <returns>Returns the response that should be sent to the sender of POST request</returns>
         Task<string> ProcessIncomingCallAsync(string content);
+
+        /// <summary>
+        /// Method responsible for processing the data sent with POST request to incoming call URL
+        /// </summary>
+        /// <param name="content">The content of request</param>
+        /// <param name="queryParameters">The query parameters of request</param>
+        /// <returns>Returns the response that should be sent to the sender of POST request</returns>
+        Task<string> ProcessIncomingCallAsync(string content, IEnumerable<KeyValuePair<string, string>> queryParameters);
     }
 }


### PR DESCRIPTION
Added new property to Microsoft.Bot.Builder.Calling.Events.IncomingCallEvent:

`public IEnumerable<KeyValuePair<string, string>> IncomingCallParameters { get; set; }`
- additional modifications to support this functionality and backward compatibility of the SDK.

I needed this to be able to configure the incoming call request 
