### PR TITLE
Add code of conduct

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -26,6 +26,10 @@ When logging a bug, please be sure to include the following:
 
 # Instructions for Contributing Code
 
+## Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
 ## Contributing bug fixes and features
 
 BotBuilder is currently accepting contributions in the form of bug fixes and new features. Any submission must have an issue tracking it in the issue tracker that has been approved by the BotBuilder team. Your pull request should include a link to the bug that you are fixing. If you've submitted a PR for a bug, please post a comment in the bug to avoid duplication of effort.


### PR DESCRIPTION
Add a link to the required [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).