### PR TITLE
Prevent from server down if request body has nothing

### DIFF
--- a/Node/core/lib/bots/ChatConnector.js
+++ b/Node/core/lib/bots/ChatConnector.js
@@ -35,12 +35,11 @@ var ChatConnector = (function () {
                 _this.verifyBotFramework(req, res);
             }
             else {
-                var requestData = '';
+                var requestData = [];
                 req.on('data', function (chunk) {
-                    requestData += chunk;
-                });
-                req.on('end', function () {
-                    req.body = JSON.parse(requestData);
+                    requestData.push(chunk)
+                }).on('end', function () {
+                    req.body = Buffer.concat(body).toString();
                     _this.verifyBotFramework(req, res);
                 });
             }


### PR DESCRIPTION
How to reproduce
- Build a bot with 'botbuilder' and 'express'
- Send a request without body
- Server down

Sample bot code:
```javascript
const express = require('express');
const builder = require('botbuilder');
const app = express();

app.get('/', function(req, resp) {
  resp.send('Hello world');
});

const port = process.env.port || 3000;

app.listen(port, function(){
  console.log(`Listening on port ${port}`);
});

var connector = new builder.ChatConnector({
    appId: process.env.MICROSOFT_APP_ID,
    appPassword: process.env.MICROSOFT_APP_PASSWORD
});
var bot = new builder.UniversalBot(connector);
app.post('/api/messages', connector.listen());

bot.dialog('/', function(session) {
    session.send("Hello World");
});
```

Sample request:
`% curl -X POST http://localhost:3978/api/messages`

```
Stack trace
SyntaxError: Unexpected end of JSON input
    at Object.parse (native)
    at IncomingMessage.<anonymous> (botbuilder/lib/bots/ChatConnector.js:43:37)
    at emitNone (events.js:86:13)
    at IncomingMessage.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:975:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

version
```
package.json

  "dependencies": {
    "botbuilder": "^3.2.3",
    "express": "^4.14.0"
  }
```


Reference:
https://nodejs.org/en/docs/guides/anatomy-of-an-http-transaction/#header-request-body