### PR TITLE
changed CallSession.ts to require('./workflow/Prompt')

### DIFF
--- a/Node/calling/src/CallSession.ts
+++ b/Node/calling/src/CallSession.ts
@@ -41,7 +41,7 @@ import answer = require('./workflow/AnswerAction');
 import hangup = require('./workflow/HangupAction');
 import reject = require('./workflow/RejectAction');
 import playPrompt = require('./workflow/PlayPromptAction');
-import prompt = require('./workflow/prompt');
+import prompt = require('./workflow/Prompt');
 
 export interface ICallSessionOptions {
     onSave: (done: (err: Error) => void) => void;


### PR DESCRIPTION
Changed CallSession.ts to require('./workflow/Prompt') instead of require('./workflow/prompt');

I was trying to deploy my skype calling bot on a PaaS platform on Node 6.3.1. When the app tried to start up, the platform complained with "Error: Cannot find module './workflow/prompt'". 

I changed CallSession.ts import prompt = require('./workflow/prompt') to require('./workflow/Prompt')  and it fixed my problem
