### PR TITLE
Use the callback passed to Session.options.onSend everywhere

### DIFF
--- a/Node/core/src/bots/ConsoleConnector.ts
+++ b/Node/core/src/bots/ConsoleConnector.ts
@@ -77,7 +77,7 @@ export class ConsoleConnector implements ub.IConnector {
         this.handler = handler;
     }
     
-    public send(messages: IMessage[], cb: (err: Error, conversationId?: string) => void): void {
+    public send(messages: IMessage[], done: (err: Error) => void): void {
         for (var i = 0; i < messages.length; i++ ){
             if (this.replyCnt++ > 0) {
                 console.log();
@@ -95,6 +95,8 @@ export class ConsoleConnector implements ub.IConnector {
                 }
             }
         }        
+
+        done(null);
     }
 
     public startConversation(address: IAddress, cb: (err: Error, address?: IAddress) => void): void {

--- a/Node/core/src/bots/UniversalBot.ts
+++ b/Node/core/src/bots/UniversalBot.ts
@@ -293,7 +293,7 @@ export class UniversalBot extends events.EventEmitter {
                     connector.send(list, this.errorLogger(done));
                 }, this.errorLogger(done));
             } else if (done) {
-                done;
+                done(null);
             }
         }));
     }


### PR DESCRIPTION
The callback passed to this function in `Session.sendBatch` is supposed to reset `session.sendingBatch` to `false`, making it available for further messages. However, in two cases, this callback was not called:

1. In `ConsoleConnector.send` it was simply ignored
2. In `UniversalBot.send` it was not called if an error occured

See #1023 for an example where it caused problems.