### PR TITLE
Improve numberExp regex

### DIFF
--- a/Node/core/lib/dialogs/EntityRecognizer.js
+++ b/Node/core/lib/dialogs/EntityRecognizer.js
@@ -201,7 +201,7 @@ var EntityRecognizer = (function () {
     EntityRecognizer.dateExp = /^\d{4}-\d{2}-\d{2}/i;
     EntityRecognizer.yesExp = /^(1|y|yes|yep|sure|ok|true)/i;
     EntityRecognizer.noExp = /^(2|n|no|nope|not|false)/i;
-    EntityRecognizer.numberExp = /[+-]?(?:\d+\.?\d*|\d*\.?\d+)/;
+    EntityRecognizer.numberExp = /[+-]?(?:\d+ *\.? *\d*|\d* *\.? *\d+)/;
     EntityRecognizer.ordinalWords = 'first|second|third|fourth|fifth|sixth|seventh|eigth|ninth|tenth';
     return EntityRecognizer;
 }());


### PR DESCRIPTION
When Luis.ai detects a decimal number such as 43.4, it successfully
parses it as a builtin.number entity. However, Luis adds a space before
and after the decimal point like this 43 . 4.
EntityRecognizer.parseNumber only parses and returns 43 because of the
extra spaces.

Link to bug: https://github.com/Microsoft/BotBuilder/issues/1031