### PR TITLE
Change step's phase from Completed to Ready if field is unknown.

### DIFF
--- a/CSharp/Library/FormFlow/FormDialog.cs
+++ b/CSharp/Library/FormFlow/FormDialog.cs
@@ -630,6 +630,8 @@ namespace Microsoft.Bot.Builder.FormFlow
                             {
                                 _formState.StepState = null;
                                 _formState.Next = null;
+                                if (_form.Steps[istep].Field.IsUnknown(_state) && _formState.Phase(istep) == StepPhase.Completed)
+                                    _formState.SetPhase(StepPhase.Ready);
                             }
                             if ((_formState.Phase(istep) == StepPhase.Ready || _formState.Phase(istep) == StepPhase.Responding)
                                 && step.Active(_state))


### PR DESCRIPTION
**FormDialog.MoveToNext** could skip an *Unspecified* field when moving to the next step.
Reproducing the problem:
 1. Create a **FormDialog** with 3 fields (F1, F2, F3).
 2. Let F2 depends on F1, so after setting F1 clear the current value of F2 (in F1 *validate*).
 3. Run the dialog, fill in F1 and F2 and before filling in F3 go back to F1.
After entering a value for F1, the **FormDialog** goes to F3 leaving F2 *Unspecified*. The things could be worse if F3 is active only when F2 is specified. In this case after re-entering F1 the form will be considered as completed.