### PR TITLE
Extract LuisModelAttribute variables into interface

### DIFF
--- a/CSharp/Library/Luis/LuisModel.cs
+++ b/CSharp/Library/Luis/LuisModel.cs
@@ -41,21 +41,33 @@ using Microsoft.Bot.Builder.Internals.Fibers;
 namespace Microsoft.Bot.Builder.Luis
 {
     /// <summary>
-    /// The LUIS model information.
+    /// A mockable interface for the LUIS model.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    [Serializable]
-    public class LuisModelAttribute : Attribute
+    public interface ILuisModel
     {
         /// <summary>
         /// The LUIS model ID.
         /// </summary>
-        public readonly string ModelID;
+        string ModelID { get; }
 
         /// <summary>
         /// The LUIS subscription key.
         /// </summary>
-        public readonly string SubscriptionKey;
+        string SubscriptionKey { get; }
+    }
+
+    /// <summary>
+    /// The LUIS model information.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    [Serializable]
+    public class LuisModelAttribute : Attribute, ILuisModel
+    {
+        private readonly string modelID;
+        public string ModelID => modelID;
+
+        private readonly string subscriptionKey;
+        public string SubscriptionKey => subscriptionKey;
 
         /// <summary>
         /// Construct the LUIS model information.
@@ -64,8 +76,8 @@ namespace Microsoft.Bot.Builder.Luis
         /// <param name="subscriptionKey">The LUIS subscription key.</param>
         public LuisModelAttribute(string modelID, string subscriptionKey)
         {
-            SetField.NotNull(out this.ModelID, nameof(modelID), modelID);
-            SetField.NotNull(out this.SubscriptionKey, nameof(subscriptionKey), subscriptionKey);
+            SetField.NotNull(out this.modelID, nameof(modelID), modelID);
+            SetField.NotNull(out this.subscriptionKey, nameof(subscriptionKey), subscriptionKey);
         }
     }
 }

--- a/CSharp/Library/Luis/LuisService.cs
+++ b/CSharp/Library/Luis/LuisService.cs
@@ -69,13 +69,13 @@ namespace Microsoft.Bot.Builder.Luis
     [Serializable]
     public sealed class LuisService : ILuisService
     {
-        private readonly LuisModelAttribute model;
+        private readonly ILuisModel model;
 
         /// <summary>
         /// Construct the LUIS service using the model information.
         /// </summary>
         /// <param name="model">The LUIS model information.</param>
-        public LuisService(LuisModelAttribute model)
+        public LuisService(ILuisModel model)
         {
             SetField.NotNull(out this.model, nameof(model), model);
         }

--- a/CSharp/Samples/AlarmBot/Models/AlarmModule.cs
+++ b/CSharp/Samples/AlarmBot/Models/AlarmModule.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Sample.AlarmBot.Models
         {
             base.Load(builder);
 
-            builder.Register(c => new LuisModelAttribute("c413b2ef-382c-45bd-8ff0-f76d60e2a821", "6d0966209c6e4f6b835ce34492f3e6d9")).AsSelf().SingleInstance();
+            builder.Register(c => new LuisModelAttribute("c413b2ef-382c-45bd-8ff0-f76d60e2a821", "6d0966209c6e4f6b835ce34492f3e6d9")).AsSelf().AsImplementedInterfaces().SingleInstance();
 
             // register the top level dialog
             builder.RegisterType<AlarmLuisDialog>().As<IDialog<object>>().InstancePerDependency();


### PR DESCRIPTION
See #1160 for discussion on implementation. This change will allow `LuisService`s to be instantiated through any object that implements the new `ILuisModel`, allowing users to more easily load from a config file or dynamically through IoC.