### PR TITLE
Fix missing callback in catch block

### DIFF
--- a/Node/core/src/dialogs/LuisRecognizer.ts
+++ b/Node/core/src/dialogs/LuisRecognizer.ts
@@ -136,6 +136,7 @@ export class LuisRecognizer implements intent.IIntentRecognizer {
                     }
                 } catch (e) {
                     console.error(e.toString());
+                    callback(e);
                 }
             });
         } catch (err) {


### PR DESCRIPTION
A callback call was missing in this try/catch block.
The code of this function is a bit weird. It relies on too many try/catch blocks that could be avoided.
In fact, this catch (line 137) looks like a just-in-case catch, I can't figure out why it's needed. You probably could verify it and get rid of it.