### PR TITLE
Make the bot calling timeouts to be doubles instead of uints.

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder.Calling/Models/Contracts/Recognize.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Calling/Models/Contracts/Recognize.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Bot.Builder.Calling.ObjectModel.Contracts
         /// Default : 5 secs
         /// </summary>
         [JsonProperty(Required = Required.Default)]
-        public uint? InitialSilenceTimeoutInSeconds { get; set; }
+        public double? InitialSilenceTimeoutInSeconds { get; set; }
 
         /// <summary>
         /// Mamimum allowed time between digits if we are doing dtmf based choice recognition or CollectDigits recognition
@@ -47,7 +47,7 @@ namespace Microsoft.Bot.Builder.Calling.ObjectModel.Contracts
         /// Default : 1 sec
         /// </summary>
         [JsonProperty(Required = Required.Default)]
-        public uint? InterdigitTimeoutInSeconds { get; set; }
+        public double? InterdigitTimeoutInSeconds { get; set; }
 
         /// <summary>
         /// List of choices to recognize against. Choices can be speech or dtmf based.

--- a/CSharp/Library/Microsoft.Bot.Builder.Calling/Models/Contracts/Record.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Calling/Models/Contracts/Record.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Builder.Calling.ObjectModel.Contracts
         /// Maximum duration of recording . Default : 180 secs
         /// </summary>
         [JsonProperty(Required = Required.Default)]
-        public uint? MaxDurationInSeconds { get; set; }
+        public double? MaxDurationInSeconds { get; set; }
 
         /// <summary>
         /// Maximum initial silence allowed from the time we start the recording operation 
@@ -31,7 +31,7 @@ namespace Microsoft.Bot.Builder.Calling.ObjectModel.Contracts
         /// Default : 5
         /// </summary>
         [JsonProperty(Required = Required.Default)]
-        public uint? InitialSilenceTimeoutInSeconds { get; set; }
+        public double? InitialSilenceTimeoutInSeconds { get; set; }
 
         /// <summary>
         /// Maximum allowed silence once the user has started speaking before we conclude 
@@ -40,7 +40,7 @@ namespace Microsoft.Bot.Builder.Calling.ObjectModel.Contracts
         /// Default : 1
         /// </summary>
         [JsonProperty(Required = Required.Default)]
-        public uint? MaxSilenceTimeoutInSeconds { get; set; }
+        public double? MaxSilenceTimeoutInSeconds { get; set; }
 
         /// <summary>
         /// The format is which the recording is expected.

--- a/CSharp/Library/Microsoft.Bot.Builder.Calling/Models/Misc/MinValues.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Calling/Models/Misc/MinValues.cs
@@ -7,13 +7,13 @@ namespace Microsoft.Bot.Builder.Calling.ObjectModel.Misc
         /// <summary>
         /// JSON Content Type
         /// </summary>
-        public static readonly TimeSpan RecordingDuration = TimeSpan.FromSeconds(10);
+        public static readonly TimeSpan RecordingDuration = TimeSpan.FromSeconds(2.0);
 
         ///<summary>
         /// Minimum allowed silence once the user has started speaking before we conclude 
         /// the user is done recording.
         /// </summary>
-        public static readonly TimeSpan SilenceTimeout = TimeSpan.FromSeconds(1);
+        public static readonly TimeSpan SilenceTimeout = TimeSpan.FromSeconds(0.0);
 
         /// <summary>
         /// Minimum initial silence allowed from the time we start the operation 


### PR DESCRIPTION
This change allows for timeouts that are fractions of a second or are smaller than 1 second in bot calling contracts. The change allows for double timeouts in Recognize and Record action.