### PR TITLE
Fix ResumptionCookie deserialization error

### DIFF
--- a/CSharp/Library/Dialogs/Address.cs
+++ b/CSharp/Library/Dialogs/Address.cs
@@ -44,6 +44,11 @@ namespace Microsoft.Bot.Builder.Dialogs
     [Serializable]
     public sealed class Address : IEquatable<Address>
     {
+        public Address()
+        {
+
+        }
+
         public Address(IActivity activity)
             : this(
                       // purposefully using named arguments because these all have the same type
@@ -70,11 +75,11 @@ namespace Microsoft.Bot.Builder.Dialogs
             this.ConversationId = conversationId;
             this.ServiceUrl = serviceUrl;
         }
-        public string BotId { get; }
-        public string ChannelId { get; }
-        public string UserId { get; }
-        public string ConversationId { get; }
-        public string ServiceUrl { get; }
+        public string BotId { get; set;  }
+        public string ChannelId { get; set;  }
+        public string UserId { get; set; }
+        public string ConversationId { get; set; }
+        public string ServiceUrl { get; set; }
 
         public bool Equals(Address other)
         {

--- a/CSharp/Library/Dialogs/ResumptionCookie.cs
+++ b/CSharp/Library/Dialogs/ResumptionCookie.cs
@@ -75,6 +75,11 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </summary>
         public string Locale { set; get; }
 
+        public ResumptionCookie()
+        {
+
+        }
+
         /// <summary>
         /// Creates an instance of the resumption cookie. 
         /// </summary>


### PR DESCRIPTION
Following the ResumptionCookie class refactoring, this code will fail:
`var resumptionCookie = UrlToken.Decode<ResumptionCookie>(state);`

(it's used for example for [Auth](https://github.com/gohlivor/AuthBot/blob/master/AuthBot/Controllers/OAuthCallbackController.cs#L65) )

The Address and ResumptionCookie classes can't be deserialized anymore. I fixed that but you may not want the setters I added on the Address properties.