### PR TITLE
[NODE] Fix: Later definition of connectors

### DIFF
--- a/Node/core/src/bots/UniversalBot.ts
+++ b/Node/core/src/bots/UniversalBot.ts
@@ -108,12 +108,6 @@ export class UniversalBot extends events.EventEmitter {
 
         if (connector) {
             this.connector(consts.defaultConnector, connector);
-            var asStorage: bs.IBotStorage = <any>connector;
-            if (!this.settings.storage && 
-                typeof asStorage.getData === 'function' &&
-                typeof asStorage.saveData === 'function') {
-                this.settings.storage = asStorage;
-            }
         }
     }
     
@@ -136,7 +130,14 @@ export class UniversalBot extends events.EventEmitter {
     
     public connector(channelId: string, connector?: IConnector): IConnector {
         var c: IConnector;
+
         if (connector) {
+            var asStorage: bs.IBotStorage = <any>connector;
+            if (!this.settings.storage && 
+                typeof asStorage.getData === 'function' &&
+                typeof asStorage.saveData === 'function') {
+                this.settings.storage = asStorage;
+            }
             this.connectors[channelId || consts.defaultConnector] = c = connector;
             c.onEvent((events, cb) => this.receive(events, cb));
         } else if (this.connectors.hasOwnProperty(channelId)) {


### PR DESCRIPTION
Currently, a Connector implements `IConnector` and `IBotStorage` (`export class ChatConnector implements ub.IConnector, bs.IBotStorage`) and the `IBotStorage` initialization code is performed only in the constructor.

The FIX mimics the initialization at constructor, but allows defered connector setting:  only the first `IBotStorage` implementation from the first `Connector` provided is used as the provided storage. Next calls to `connector` only adds the `IConnector` functionality, discarding the *mixed* `IBotStorage` part

Fixes #1382