### PR TITLE
[Fix] Group conversation message

### DIFF
--- a/Node/core/lib/bots/ChatConnector.js
+++ b/Node/core/lib/bots/ChatConnector.js
@@ -497,6 +497,8 @@ var ChatConnector = (function () {
             'channelData': 'sourceEvent'
         });
         msg.text = msg.text || '';
+        if (msg.conversation.isGroup)
+            msg.text = /<\/at>\s?(.*?)$/g.exec(msg.text)[1];
         msg.attachments = msg.attachments || [];
         msg.entities = msg.entities || [];
         var address = {};


### PR DESCRIPTION
BotBuilder v3.2.3
In a conversation group my bot receive message with the "@(Bot)".
The `text` var contains "\<at id='xxxxxx'\>PersoBotTest\</at\> MSG"

Example : 
```javascript
{ type: 'message',
  id: 'xxxxxxxxxxxxx',
  timestamp: '2016-10-07T00:05:30.903Z',
  serviceUrl: 'https://skype.botframework.com',
  channelId: 'skype',
  from: 
   { id: 'xxxxxxxxxxxxxx',
     name: 'Skype Login' },
  conversation: 
   { isGroup: true,
     id: 'xxxxxxxxxxxxxxxxx' },
  recipient: 
   { id: 'xxxxxxxxxxxxxxxxxxxxxxxxxx',
     name: 'PersoTest' },
  text: '<at id="xxxxxxxxxxxxxxxxxxx">PersoTestBot</at> test',
  entities: 
   [ { mentioned: [Object],
       text: '<at id="xxxxxxxxxxxxxxxxxxx">PersoTestBot</at>',
       type: 'mention' } ],
  useAuth: true }
```