### PR TITLE
[Node] Propagate types in endDialogWithResult

### DIFF
--- a/Node/core/lib/botbuilder.d.ts
+++ b/Node/core/lib/botbuilder.d.ts
@@ -1,4 +1,4 @@
-﻿//=============================================================================
+//=============================================================================
 //
 // INTERFACES
 //
@@ -1087,7 +1087,7 @@ export class Session {
     /**
      * Ends the current dialog and optionally returns a result to the dialogs parent. 
      */
-    endDialogWithResult(result?: IDialogResult<any>): Session;
+    endDialogWithResult<T>(result?: IDialogResult<T>): Session;
     
     /** 
      * Cancels an existing dialog and optionally starts a new one it its place.  Unlike [endDialog()](#enddialog)


### PR DESCRIPTION
`IDialogResult<T>` interface has a template syntax, so `endDialogWithResult` which takes that interface as argument, should propagate the template