### PR TITLE
[Node] Definitions for IDialogResult.resumed

### DIFF
--- a/Node/core/src/botbuilder.d.ts
+++ b/Node/core/src/botbuilder.d.ts
@@ -385,8 +385,8 @@ export interface IDialogState {
   * Results returned by a child dialog to its parent via a call to session.endDialog(). 
   */
 export interface IDialogResult<T> {
-    /** The reason why the current dialog is being resumed. */
-    resumed: ResumeReason;
+    /** The reason why the current dialog is being resumed. Defaults to {ResumeReason.completed} */
+    resumed?: ResumeReason;
 
     /** ID of the child dialog thats ending. */
     childId?: string;


### PR DESCRIPTION
The current implementation [makes a guard over not defining the `resumed` property](https://github.com/Microsoft/BotBuilder/blob/e8c5aaaa273f6265fd983e5ded2f3b147a9867b6/Node/core/src/Session.ts#L297-L299), so it should be optional in TS to avoid generating verbose code

before
```ts
session.endDialogWithResult({
  resumed: BotBuilder.ResumeReason.completed,
  response: true
});
```

after
```ts
session.endDialogWithResult({
  response: true
});
```