### PR TITLE
Authorise MSA self-issued tokens in the node SDK (as in the .NET SDK)…

### DIFF
--- a/Node/core/lib/bots/ChatConnector.js
+++ b/Node/core/lib/bots/ChatConnector.js
@@ -63,7 +63,13 @@ var ChatConnector = (function () {
             var decoded = jwt.decode(token, { complete: true });
             var verifyOptions;
             var openIdMetadata;
-            if (isEmulator && decoded.payload.iss == this.settings.endpoint.msaIssuer) {
+            if (decoded.payload.iss == this.settings.endpoint.msaIssuer) {
+                if(decoded.payload.appid !== this.settings.appId) {
+                    logger.error('ChatConnector: receive - invalid token. Check bot\'s app ID.');
+                    res.status(403);
+                    res.end();
+                    return;
+                }
                 openIdMetadata = this.msaOpenIdMetadata;
                 verifyOptions = {
                     issuer: this.settings.endpoint.msaIssuer,


### PR DESCRIPTION
The C# SDK allows to use self-issues tokens, not only for the emulator but for any channel as long as the AppId of the Bot is matching the one from the token:
https://github.com/Microsoft/BotBuilder/blob/5cf71c742f27d89e9dbc4076f850122bd6edac11/CSharp/Library/Microsoft.Bot.Connector/BotAuthentication.cs#L45

Additionally, I think the node SDK currently allows any MSA-issued token to communicate with the bot as long as the channelId field contains "emulator". I think it may be a security issue. At least the SDK should also check the appId for the emulator channel.
