### PR TITLE
Use the default locale in case invalid received

### DIFF
--- a/Node/core/src/DefaultLocalizer.ts
+++ b/Node/core/src/DefaultLocalizer.ts
@@ -44,6 +44,11 @@ export class DefaultLocalizer implements ILocalizer {
     private locales: { [locale:string]: ILocaleEntry; } = {}
 
     constructor(root: lib.Library, defaultLocale = 'en') {
+        if (!defaultLocale) {
+            // All "falsy" values can be considered invalid so
+            // fallback to the default instead.
+            defaultLocale = 'en';
+        }
         this.defaultLocale(defaultLocale);
 
         // Find all of the searchable 


### PR DESCRIPTION
The default parameter is used only if no parameter is passed and to avoid
accepting other invalid values, this additional check is required.

Fixes #1540.