### PR TITLE
Fix loop indexes are being meshed up in the ConsoleConnector

### DIFF
--- a/Node/core/src/bots/ConsoleConnector.ts
+++ b/Node/core/src/bots/ConsoleConnector.ts
@@ -40,7 +40,7 @@ export class ConsoleConnector implements ub.IConnector {
     private handler: (events: IEvent[], cb?: (err: Error) => void) => void;
     private rl: readline.ReadLine;
     private replyCnt = 0;
-    
+
     public listen(): this {
         this.rl = readline.createInterface({ input: process.stdin, output: process.stdout, terminal: false });
         this.rl.on('line', (line: string) => {
@@ -72,11 +72,11 @@ export class ConsoleConnector implements ub.IConnector {
         }
         return this;
     }
-    
+
     public onEvent(handler: (events: IEvent[], cb?: (err: Error) => void) => void): void {
         this.handler = handler;
     }
-    
+
     public send(messages: IMessage[], done: (err: Error) => void): void {
         for (var i = 0; i < messages.length; i++ ){
             if (this.replyCnt++ > 0) {
@@ -87,14 +87,14 @@ export class ConsoleConnector implements ub.IConnector {
                 log(msg.text);
             }
             if (msg.attachments && msg.attachments.length > 0) {
-                for (var i = 0; i < msg.attachments.length; i++) {
-                    if (i > 0) {
+                for (var j = 0; j < msg.attachments.length; j++) {
+                    if (j > 0) {
                         console.log();
                     }
-                    renderAttachment(msg.attachments[i]);
+                    renderAttachment(msg.attachments[j]);
                 }
             }
-        }        
+        }
 
         done(null);
     }


### PR DESCRIPTION
Fixes #1570

The ConsoleConnector is declaring the same variable `i` in two nested loops, which mades the inner loop to modify the value of the outer loop index.
Some of the consequences of this bug are described in #1570.

This could be solved using `let` instead of `var` but I've seen that you are not using `let` in the framework, so I've renamed the inner loop index from `i` to `j`.
