### PR TITLE
facebook is missing as a trusted hostname

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Connector/MicrosoftAppCredentials.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector/MicrosoftAppCredentials.cs
@@ -17,10 +17,12 @@ namespace Microsoft.Bot.Connector
 {
     public class MicrosoftAppCredentials : ServiceClientCredentials
     {
-        protected static ConcurrentDictionary<string, DateTime> TrustedHostNames = new ConcurrentDictionary<string, DateTime>(
-                                                                                        new Dictionary<string, DateTime>() {
-                                                                                            { "state.botframework.com", DateTime.MaxValue }
-                                                                                        });
+        protected static ConcurrentDictionary<string, DateTime> TrustedHostNames = 
+            new ConcurrentDictionary<string, DateTime>(
+                new Dictionary<string, DateTime>() {
+                    { "state.botframework.com", DateTime.MaxValue },
+                    { "facebook.botframework.com", DateTime.MaxValue }
+            });
 
         public MicrosoftAppCredentials(string appId = null, string password = null)
         {


### PR DESCRIPTION
Connector calls to facebook.botframework.com are Forbidden because the the url is not part of the list of trusted hostnames. See #1597