### PR TITLE
Fixed "Parameter count missmatch" exception for setup of QueryAsync in LuisTestBase.

### DIFF
--- a/CSharp/Tests/Microsoft.Bot.Builder.Tests/LuisTests.cs
+++ b/CSharp/Tests/Microsoft.Bot.Builder.Tests/LuisTests.cs
@@ -1,15 +1,15 @@
-﻿// 
+﻿//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
-// 
+//
 // Microsoft Bot Framework: http://botframework.com
-// 
+//
 // Bot Builder SDK Github:
 // https://github.com/Microsoft/BotBuilder
-// 
+//
 // Copyright (c) Microsoft Corporation
 // All rights reserved.
-// 
+//
 // MIT License:
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -18,10 +18,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -97,7 +97,7 @@ namespace Microsoft.Bot.Builder.Tests
 
             luis
                 .Setup(l => l.QueryAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
-                .Returns<Uri>(async (uri) =>
+                .Returns<Uri, CancellationToken>(async (uri, ct) =>
                 {
                     return new LuisResult()
                     {


### PR DESCRIPTION
Hi,

I was trying to write tests for a bot I'm building. I was looking for an inspiration in your tests. Specifically [`AlarmBotTests`](https://github.com/Microsoft/BotBuilder/blob/master/CSharp/Tests/Microsoft.Bot.Sample.Tests/AlarmBotTests.cs).

In my tests I was running into issues with "Parameter count mismatch" exceptions when invoking tests classes, so I looked at you tests more closely. 
As far as I can tell, you are not actually using mocked LUIS services even though they are set up in the test. `AlarmModule` registers actual LuisService implementation. But that is another issue.

When using actual mocked service setup should be like this, otherwise it will fails with "Parameter count missmatch" exception.
