### PR TITLE
Populate reply message with richer details in the node SDK

### DIFF
--- a/Node/core/lib/bots/ChatConnector.js
+++ b/Node/core/lib/bots/ChatConnector.js
@@ -356,11 +356,8 @@ var ChatConnector = (function () {
     };
     ChatConnector.prototype.postMessage = function (msg, cb) {
         logger.info(address, 'ChatConnector: sending message.');
-        this.prepOutgoingMessage(msg);
         var address = msg.address;
-        msg['from'] = address.bot;
-        msg['recipient'] = address.user;
-        delete msg.address;
+        this.prepOutgoingMessage(msg);
         var path = '/v3/conversations/' + encodeURIComponent(address.conversation.id) + '/activities';
         if (address.id && address.channelId !== 'skype') {
             path += '/' + encodeURIComponent(address.id);
@@ -560,6 +557,15 @@ var ChatConnector = (function () {
             'textLocale': 'locale',
             'sourceEvent': 'channelData'
         });
+        var address = msg.address;
+        msg['timestamp'] = new Date().toISOString();
+        msg['from'] = address.bot;
+        msg['recipient'] = address.user;
+        msg['replyToId'] = address.id;
+        msg['serviceUrl'] = address.serviceUrl;
+        msg['channelId'] = address.channelId;
+        msg['conversation'] = address.conversation;
+        delete msg.address;
         delete msg.agent;
         delete msg.source;
     };


### PR DESCRIPTION
The message now send back to the web connector with the Node SDK is missing some fields compare to the C# SDK. For example, replyToID and etc. 

I looked into the C# library' createReply method (https://github.com/Microsoft/BotBuilder/blob/master/CSharp/Library/Microsoft.Bot.Connector/ActivityEx.cs) and made some adjustment. So that the two SDK behave more like each other.