### PR TITLE
fix tsc errors TS2399, TS2400 in eventMiddleware

### DIFF
--- a/Node/core/src/bots/UniversalBot.ts
+++ b/Node/core/src/bots/UniversalBot.ts
@@ -467,17 +467,16 @@ export class UniversalBot extends Library {
 
     private eventMiddleware(event: IEvent, middleware: IEventMiddleware[], done: Function, error?: (err: Error) => void): void {
         var i = -1;
-        var _this = this;
         function next() {
             if (++i < middleware.length) {
-                _this.tryCatch(() => {
+                this.tryCatch(() => {
                     middleware[i](event, next);
                 }, () => next());
             } else {
-                _this.tryCatch(() => done(), error);
+                this.tryCatch(() => done(), error);
             }
         }
-        next();
+        next.apply(this);
     }
 
     private isMessage(message: IMessage): boolean {


### PR DESCRIPTION
Compiling with tsc led to the following errors:
bots/UniversalBot.ts(470,13): error TS2399: Duplicate identifier '_this'. Compiler uses variable declaration '_this' to capture 'this' reference.
bots/UniversalBot.ts(473,17): error TS2400: Expression resolves to variable declaration '_this' that compiler uses to capture 'this' reference.
bots/UniversalBot.ts(477,17): error TS2400: Expression resolves to variable declaration '_this' that compiler uses to capture 'this' reference.

Caching the 'this' pointer wasn't necessary, calling ```next.apply(this)``` has the same effect.