### PR TITLE
[C# SDK] Changed ResolutionParser to use the EntityRecommendation.Type parameter

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/Extensions.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/Extensions.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Bot.Builder.Luis
                 foreach (var entity in entities)
                 {
                     Resolution resolution;
-                    if (parser.TryParse(entity.Resolution, out resolution))
+                    if (parser.TryParse(entity, out resolution))
                     {
                         yield return resolution;
                     }

--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/Resolution.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/Resolution.cs
@@ -31,6 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using Microsoft.Bot.Builder.Luis.Models;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -308,48 +309,47 @@ namespace Microsoft.Bot.Builder.Luis
 
     public interface IResolutionParser
     {
-        bool TryParse(IDictionary<string, string> properties, out Resolution resolution);
+        bool TryParse(EntityRecommendation entityRecommendation, out Resolution resolution);
     }
 
     public sealed class ResolutionParser : IResolutionParser
     {
-        bool IResolutionParser.TryParse(IDictionary<string, string> properties, out Resolution resolution)
+        bool IResolutionParser.TryParse(EntityRecommendation entityRecommendation, out Resolution resolution)
         {
-            string resolution_type;
-            if (properties != null)
+
+            if (entityRecommendation != null)
             {
-                if (properties.TryGetValue("resolution_type", out resolution_type))
+                IDictionary<string, string> properties = entityRecommendation.Resolution;
+
+                switch (entityRecommendation.Type)
                 {
-                    switch (resolution_type)
-                    {
-                        case "builtin.datetime.date":
-                            string date;
-                            if (properties.TryGetValue("date", out date))
+                    case "builtin.datetime.date":
+                        string date;
+                        if (properties.TryGetValue("date", out date))
+                        {
+                            BuiltIn.DateTime.DateTimeResolution dateTime;
+                            if (BuiltIn.DateTime.DateTimeResolution.TryParse(date, out dateTime))
                             {
-                                BuiltIn.DateTime.DateTimeResolution dateTime;
-                                if (BuiltIn.DateTime.DateTimeResolution.TryParse(date, out dateTime))
-                                {
-                                    resolution = dateTime;
-                                    return true;
-                                }
+                                resolution = dateTime;
+                                return true;
                             }
+                        }
 
-                            break;
-                        case "builtin.datetime.time":
-                        case "builtin.datetime.set":
-                            string time;
-                            if (properties.TryGetValue("time", out time))
+                        break;
+                    case "builtin.datetime.time":
+                    case "builtin.datetime.set":
+                        string time;
+                        if (properties.TryGetValue("time", out time))
+                        {
+                            BuiltIn.DateTime.DateTimeResolution dateTime;
+                            if (BuiltIn.DateTime.DateTimeResolution.TryParse(time, out dateTime))
                             {
-                                BuiltIn.DateTime.DateTimeResolution dateTime;
-                                if (BuiltIn.DateTime.DateTimeResolution.TryParse(time, out dateTime))
-                                {
-                                    resolution = dateTime;
-                                    return true;
-                                }
+                                resolution = dateTime;
+                                return true;
                             }
+                        }
 
-                            break;
-                    }
+                        break;
                 }
             }
 

--- a/CSharp/Samples/AlarmBot/Dialogs/AlarmLuisDialog.cs
+++ b/CSharp/Samples/AlarmBot/Dialogs/AlarmLuisDialog.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Bot.Sample.AlarmBot.Dialogs
         {
             public const string Alarm_State = "builtin.alarm.alarm_state";
             public const string Duration = "builtin.alarm.duration";
-            public const string Start_Date = "builtin.alarm.start_date";
-            public const string Start_Time = "builtin.alarm.start_time";
+            public const string Start_Date = "builtin.datetime.date";
+            public const string Start_Time = "builtin.datetime.time";
             public const string Title = "builtin.alarm.title";
         }
     }


### PR DESCRIPTION
Changed ResolutionParser to use the EntityRecommendation.Type parameter instead of looking in the Resolution dictionary for a "resolution_type" key. This is due to changes in the LUIS API V2, see https://github.com/Microsoft/BotBuilder/issues/1797