### PR TITLE
[Node SDK] Fix type signature

### DIFF
--- a/Node/core/src/dialogs/ActionSet.ts
+++ b/Node/core/src/dialogs/ActionSet.ts
@@ -45,7 +45,7 @@ export interface IActionHandler {
 export interface IDialogActionOptions {
     matches?: RegExp|RegExp[]|string|string[];
     intentThreshold?: number;
-    onFindAction?: (context: IFindActionRouteContext, callback: (err: Error, score: number, routeData?: IActionRouteData) => void) => void;
+    onFindAction?: (context: IFindActionRouteContext, callback: (err: Error | null, score: number, routeData?: IActionRouteData) => void) => void;
     onSelectAction?: (session: Session, args?: any, next?: Function) => void;
     label?: string;
 }


### PR DESCRIPTION
It should be possible to invoke the callback without an error, hence the signature change.

I went for the `err: Error | null` signature because:

- it's called with `null` in [some examples](https://github.com/Microsoft/BotBuilder/blob/master/Node/examples/feature-onFindAction/app.js#L33)
- it mimics nodejs's stdlib behaviour

(I guess the alternative could have been `err?: Error`, copying the `ErrorCallback` signature of the `async` library used elsewhere in the code, or `err?: Error | null`, merging the two possibilities.)

In any case, I did not change [how the error is handled](https://github.com/Microsoft/BotBuilder/blob/2826c4757be5488ecc13926ecdf540254bf9715d/Node/core/src/dialogs/ActionSet.ts#L182) to make it only check for `err !== null`, as it would be a breaking change.