### PR TITLE
[C# SDK] Api feedback improvements

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/BotData.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/BotData.cs
@@ -38,10 +38,8 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Configuration;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -65,7 +63,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
         /// <param name="botStoreType"> The bot store type.</param>
         /// <param name="cancellationToken"> The cancellation token.</param>
         /// <returns>Bot record that is stored for this key, or "empty" bot record ready to be stored</returns>
-        Task<T> LoadAsync(IAddress key, BotStoreType botStoreType, CancellationToken cancellationToken);
+        Task<T> LoadAsync(IAddress key, BotStoreType botStoreType, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Save a BotData using the ETag.
@@ -80,8 +78,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
         /// <param name="data"> The data that should be saved.</param>
         /// <param name="cancellationToken"> The cancellation token.</param>
         /// <returns>throw HttpException(HttpStatusCode.PreconditionFailed) if update fails</returns>
-        Task SaveAsync(IAddress key, BotStoreType botStoreType, T data, CancellationToken cancellationToken);
-        Task<bool> FlushAsync(IAddress key, CancellationToken cancellationToken);
+        Task SaveAsync(IAddress key, BotStoreType botStoreType, T data, CancellationToken cancellationToken = default(CancellationToken));
+        Task<bool> FlushAsync(IAddress key, CancellationToken cancellationToken = default(CancellationToken));
     }
 
     /// <summary>
@@ -144,7 +142,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             }
         }
 
-        Task<bool> IBotDataStore<BotData>.FlushAsync(IAddress key, CancellationToken cancellationToken)
+        Task<bool> IBotDataStore<BotData>.FlushAsync(IAddress key, CancellationToken cancellationToken )
         {
             // Everything is saved. Flush is no-op
             return Task.FromResult(true);
@@ -222,7 +220,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             return botData;
         }
 
-        async Task IBotDataStore<BotData>.SaveAsync(IAddress key, BotStoreType botStoreType, BotData botData, CancellationToken cancellationToken)
+        async Task IBotDataStore<BotData>.SaveAsync(IAddress key, BotStoreType botStoreType, BotData botData, CancellationToken cancellationToken )
         {
             switch (botStoreType)
             {
@@ -240,7 +238,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             }
         }
 
-        Task<bool> IBotDataStore<BotData>.FlushAsync(IAddress key, CancellationToken cancellationToken)
+        Task<bool> IBotDataStore<BotData>.FlushAsync(IAddress key, CancellationToken cancellationToken )
         {
             // Everything is saved. Flush is no-op
             return Task.FromResult(true);
@@ -287,7 +285,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             public BotData BotUserData { set; get; }
         }
 
-        async Task<bool> IBotDataStore<BotData>.FlushAsync(IAddress key, CancellationToken cancellationToken)
+        async Task<bool> IBotDataStore<BotData>.FlushAsync(IAddress key, CancellationToken cancellationToken )
         {
             CacheEntry entry;
             if (cache.TryGetValue(key, out entry))
@@ -306,7 +304,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             }
         }
 
-        async Task<BotData> IBotDataStore<BotData>.LoadAsync(IAddress key, BotStoreType botStoreType, CancellationToken cancellationToken)
+        async Task<BotData> IBotDataStore<BotData>.LoadAsync(IAddress key, BotStoreType botStoreType, CancellationToken cancellationToken )
         {
             CacheEntry cacheEntry;
             BotData value = null;
@@ -351,7 +349,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             return value;
         }
 
-        async Task IBotDataStore<BotData>.SaveAsync(IAddress key, BotStoreType botStoreType, BotData value, CancellationToken cancellationToken)
+        async Task IBotDataStore<BotData>.SaveAsync(IAddress key, BotStoreType botStoreType, BotData value, CancellationToken cancellationToken )
         {
             CacheEntry entry;
             if (!cache.TryGetValue(key, out entry))
@@ -363,7 +361,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             SetCachedValue(entry, botStoreType, value);
         }
 
-        private async Task<BotData> LoadFromInnerAndCache(CacheEntry cacheEntry, BotStoreType botStoreType, IAddress key, CancellationToken token)
+        private async Task<BotData> LoadFromInnerAndCache(CacheEntry cacheEntry, BotStoreType botStoreType, IAddress key, CancellationToken token = default(CancellationToken))
         {
             var value = await inner.LoadAsync(key, botStoreType, token);
 
@@ -398,7 +396,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             }
         }
 
-        private async Task Save(IAddress key, CacheEntry entry, CancellationToken cancellationToken)
+        private async Task Save(IAddress key, CacheEntry entry, CancellationToken cancellationToken = default(CancellationToken))
         {
             switch (this.dataConsistencyPolicy)
             {
@@ -449,7 +447,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
     {
         private readonly IBotData inner;
         private readonly IDialogTaskManager dialogTaskManager;
-        
+
         public DialogTaskManagerBotDataLoader(IBotData inner, IDialogTaskManager dialogTaskManager)
         {
             SetField.NotNull(out this.inner, nameof(inner), inner);
@@ -459,19 +457,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
         public IBotDataBag UserData { get { return inner.UserData; } }
         public IBotDataBag ConversationData { get { return inner.ConversationData; } }
         public IBotDataBag PrivateConversationData { get { return inner.PrivateConversationData; } }
-        public async Task LoadAsync(CancellationToken token)
+        public async Task LoadAsync(CancellationToken token = default(CancellationToken))
         {
             await this.inner.LoadAsync(token);
             await this.dialogTaskManager.LoadDialogTasks(token);
         }
 
-        public async Task FlushAsync(CancellationToken token)
+        public async Task FlushAsync(CancellationToken token = default(CancellationToken))
         {
             await this.dialogTaskManager.FlushDialogTasks(token);
             await this.inner.FlushAsync(token);
         }
     }
-    
+
     public abstract class BotDataBase<T> : IBotData
     {
         protected readonly IBotDataStore<BotData> botDataStore;
@@ -489,7 +487,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
         protected abstract T MakeData();
         protected abstract IBotDataBag WrapData(T data);
 
-        public async Task LoadAsync(CancellationToken cancellationToken)
+        public async Task LoadAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             var conversationTask = LoadData(BotStoreType.BotConversationData, cancellationToken);
             var privateConversationTask = LoadData(BotStoreType.BotPrivateConversationData, cancellationToken);
@@ -500,7 +498,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             this.userData = await userTask;
         }
 
-        public async Task FlushAsync(CancellationToken cancellationToken)
+        public async Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             await this.botDataStore.FlushAsync(botDataKey, cancellationToken);
         }
@@ -532,7 +530,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             }
         }
 
-        private async Task<IBotDataBag> LoadData(BotStoreType botStoreType, CancellationToken cancellationToken)
+        private async Task<IBotDataBag> LoadData(BotStoreType botStoreType, CancellationToken cancellationToken = default(CancellationToken))
         {
             var botData = await this.botDataStore.LoadAsync(botDataKey, botStoreType, cancellationToken);
             if (botData?.Data == null)

--- a/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/BotToUser.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/BotToUser.cs
@@ -31,6 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using Microsoft.Bot.Builder.ConnectorEx;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -38,7 +39,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder.ConnectorEx;
 using Microsoft.Bot.Builder.Internals.Fibers;
 using Microsoft.Bot.Connector;
 
@@ -78,7 +78,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             return toBotActivity.CreateReply();
         }
 
-        Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken)
+        Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken )
         {
             return Task.CompletedTask;
         }
@@ -100,7 +100,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             return toBotActivity.CreateReply();
         }
 
-        async Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken)
+        async Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken )
         {
             await this.client.Conversations.ReplyToActivityAsync((Activity)message, cancellationToken);
         }
@@ -286,7 +286,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             return toBotActivity.CreateReply();
         }
 
-        async Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken)
+        async Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken )
         {
             this.queue.Enqueue(message);
         }
@@ -307,7 +307,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             return this.inner.MakeMessage();
         }
 
-        async Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken)
+        async Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken )
         {
             await this.inner.PostAsync(message, cancellationToken);
             await this.writer.WriteLineAsync($"{message.Text}{ButtonsToText(message.Attachments)}");

--- a/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/BotToUser.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/BotToUser.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             return toBotActivity.CreateReply();
         }
 
-        Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken )
+        Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -100,7 +100,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             return toBotActivity.CreateReply();
         }
 
-        async Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken )
+        async Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken)
         {
             await this.client.Conversations.ReplyToActivityAsync((Activity)message, cancellationToken);
         }
@@ -286,7 +286,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             return toBotActivity.CreateReply();
         }
 
-        async Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken )
+        async Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken)
         {
             this.queue.Enqueue(message);
         }
@@ -307,7 +307,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             return this.inner.MakeMessage();
         }
 
-        async Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken )
+        async Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken)
         {
             await this.inner.PostAsync(message, cancellationToken);
             await this.writer.WriteLineAsync($"{message.Text}{ButtonsToText(message.Attachments)}");

--- a/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/IActivityLogger.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/IActivityLogger.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
             return this.inner.MakeMessage();
         }
 
-        async Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken)
+        async Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken )
         {
             await this.logger.LogAsync(message);
             await this.inner.PostAsync(message, cancellationToken);

--- a/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/IBotData.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/IBotData.cs
@@ -60,12 +60,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
         /// Loads the bot data from <see cref="IBotDataStore{T}"/>
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
-        Task LoadAsync(CancellationToken cancellationToken);
+        Task LoadAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Flushes the bot data to <see cref="IBotDataStore{T}"/>
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
-        Task FlushAsync(CancellationToken cancellationToken);
+        Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/IBotDataBag.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/IBotDataBag.cs
@@ -108,12 +108,33 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="bag">The bot data bag.</param>
         /// <param name="key">The key of the value to get or set.</param>
         /// <returns>The value associated with the specified key. If the specified key is not found, a get operation throws a KeyNotFoundException.</returns>
+        /// <exception cref="KeyNotFoundException"><paramref name="key"/></exception>
         public static T GetValue<T>(this IBotDataBag bag, string key)
         {
             T value;
             if (!bag.TryGetValue(key, out value))
             {
                 throw new KeyNotFoundException(key);
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Gets the value associated with the specified key or a default value if not found.
+        /// </summary>
+        /// <typeparam name="T">The type of the value to get.</typeparam>
+        /// <param name="bag">The bot data bag.</param>
+        /// <param name="key">The key of the value to get or set.</param>
+        /// <param name="defaultValue">The value to return if the key is not present</param>
+        /// <returns>The value associated with the specified key. If the specified key is not found, <paramref name="defaultValue"/>
+        /// is returned </returns>
+        public static T GetValueOrDefault<T>(this IBotDataBag bag, string key, T defaultValue = default(T))
+        {
+            T value;
+            if (!bag.TryGetValue(key, out value))
+            {
+                value = defaultValue;
             }
 
             return value;

--- a/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/IBotDataBag.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/IBotDataBag.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// Gets the number of key/value pairs contained in the <see cref="IBotDataBag"/>.
         /// </summary>
         int Count { get; }
-        
+
         /// <summary>
         /// Checks if data bag contains a value with specified key
         /// </summary>
@@ -89,6 +89,18 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// </summary>
     public static partial class Extensions
     {
+        [System.Obsolete(@"Use GetValue<T> instead", false)]
+        public static T Get<T>(this IBotDataBag bag, string key)
+        {
+            T value;
+            if (!bag.TryGetValue(key, out value))
+            {
+                throw new KeyNotFoundException(key);
+            }
+
+            return value;
+        }
+
         /// <summary>
         /// Gets the value associated with the specified key.
         /// </summary>
@@ -96,7 +108,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="bag">The bot data bag.</param>
         /// <param name="key">The key of the value to get or set.</param>
         /// <returns>The value associated with the specified key. If the specified key is not found, a get operation throws a KeyNotFoundException.</returns>
-        public static T Get<T>(this IBotDataBag bag, string key)
+        public static T GetValue<T>(this IBotDataBag bag, string key)
         {
             T value;
             if (!bag.TryGetValue(key, out value))

--- a/CSharp/Library/Microsoft.Bot.Builder/Dialogs/DialogContext.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Dialogs/DialogContext.cs
@@ -31,13 +31,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using Microsoft.Bot.Builder.Internals.Fibers;
+using Microsoft.Bot.Connector;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-
-using Microsoft.Bot.Builder.Internals.Fibers;
-using Microsoft.Bot.Connector;
 
 namespace Microsoft.Bot.Builder.Dialogs.Internals
 {

--- a/CSharp/Library/Microsoft.Bot.Builder/Dialogs/IDialogContext.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Dialogs/IDialogContext.cs
@@ -32,11 +32,11 @@
 //
 
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-
+using System;
 using Microsoft.Bot.Builder.Dialogs.Internals;
 using Microsoft.Bot.Connector;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
@@ -209,7 +209,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="message">The message that will be posted to child dialog.</param>
         /// <param name="token">A cancellation token.</param>
         /// <returns>A task representing the Forward operation.</returns>
-        public static async Task Forward<R>(this IDialogStack stack, IDialog<R> child, ResumeAfter<R> resume, IMessageActivity message, CancellationToken token)
+        public static async Task Forward<R>(this IDialogStack stack, IDialog<R> child, ResumeAfter<R> resume, IMessageActivity message, CancellationToken token = default(CancellationToken))
         {
             await stack.Forward<R, IMessageActivity>(child, resume, message, token);
         }

--- a/CSharp/Library/Microsoft.Bot.Builder/Dialogs/PromptDialog.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Dialogs/PromptDialog.cs
@@ -413,7 +413,23 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="titles">Titles to display for choices.</param>
         public static void Choice<T>(IDialogContext context, ResumeAfter<T> resume, string prompt, IEnumerable<T> values, IEnumerable<string> titles = null, string retry = null, int attempts = 3, PromptStyle promptStyle = PromptStyle.Auto)
         {
-            Choice(context, resume, new PromptOptions<T>(prompt, retry: retry, attempts: attempts, values: optionValues, promptStyler: new PromptStyler(promptStyle), titles: optionDescriptions));
+            Choice(context, resume, values.Select((o, i) => new KeyValuePair<string, T>(titles?.ElementAt(i) ?? o.ToString(), o)), prompt, retry, attempts, promptStyle);
+        }
+
+        /// <summary>   Prompt for one of a set of choices. </summary>
+        /// <param name="context">  The context. </param>
+        /// <param name="resume">   Resume handler. </param>
+        /// <param name="options">  The set of options (all of which must be convertible to a string) and their description.</param>
+        /// <param name="prompt">   The prompt to show to the user. </param>
+        /// <param name="retry">    What to show on retry. </param>
+        /// <param name="attempts"> The number of times to retry. </param>
+        /// <param name="promptStyle"> Style of the prompt <see cref="PromptStyle" /> </param>
+        public static void Choice<T>(IDialogContext context, ResumeAfter<T> resume, IEnumerable<KeyValuePair<string, T>> options, string prompt, string retry = null, int attempts = 3, PromptStyle promptStyle = PromptStyle.Auto)
+        {
+            var optionValues = options.Select(i => i.Value).ToList();
+            var optionTitles = options.Select(i => i.Key.ToString()).ToList();
+
+            Choice(context, resume, new PromptOptions<T>(prompt, retry: retry, attempts: attempts, values: optionValues, promptStyler: new PromptStyler(promptStyle), titles: optionTitles));
         }
 
         /// <summary>   Prompt for one of a set of choices. </summary>

--- a/CSharp/Library/Microsoft.Bot.Builder/Dialogs/PromptDialog.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Dialogs/PromptDialog.cs
@@ -172,24 +172,24 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="prompt"> The prompt.</param>
         /// <param name="retry"> What to display on retry.</param>
         /// <param name="tooManyAttempts"> What to display when user didn't say a valid response after <see cref="Attempts"/>.</param>
-        /// <param name="options"> The prompt choice values.</param>
+        /// <param name="values"> The prompt choice values.</param>
         /// <param name="attempts"> Maximum number of attempts.</param>
         /// <param name="promptStyler"> The prompt styler.</param>
-        /// <param name="descriptions">Descriptions for each prompt.</param>
+        /// <param name="titles">Descriptions for each prompt.</param>
         /// <param name="speak"> The Speak tag (SSML markup for text to speech).</param>
         /// <param name="retrySpeak"> What to display on retry Speak (SSML markup for text to speech).</param>
         /// <param name="recognizer"> Entity Recognizer to parse the message content.</param>
-        public PromptOptions(string prompt, string retry = null, string tooManyAttempts = null, IReadOnlyList<T> options = null, int attempts = 3, PromptStyler promptStyler = null, IReadOnlyList<string> descriptions = null, string speak = null, string retrySpeak = null, IPromptRecognizer recognizer = null)
+        public PromptOptions(string prompt, IReadOnlyList<string> titles = null, IReadOnlyList<T> values = null, string retry = null, string tooManyAttempts = null, int attempts = 3, PromptStyler promptStyler = null, string speak = null, string retrySpeak = null, IPromptRecognizer recognizer = null)
             : this(prompt,
-                  retry,
-                  tooManyAttempts,
-                  options != null ? new ReadOnlyDictionary<T, IReadOnlyList<T>>(options.ToDictionary(x => x, x => (IReadOnlyList<T>)Enumerable.Empty<T>().ToList().AsReadOnly())) : null,
-                  attempts,
-                  promptStyler,
-                  descriptions,
-                  speak,
-                  retrySpeak,
-                  recognizer)
+                titles,
+                values != null ? new ReadOnlyDictionary<T, IReadOnlyList<T>>(values.ToDictionary(x => x, x => (IReadOnlyList<T>)Enumerable.Empty<T>().ToList().AsReadOnly())) : null,
+                retry,
+                tooManyAttempts,
+                attempts,
+                promptStyler,
+                speak,
+                retry,
+                recognizer)
         {
         }
 
@@ -199,14 +199,14 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="prompt"> The prompt.</param>
         /// <param name="retry"> What to display on retry.</param>
         /// <param name="tooManyAttempts"> What to display when user didn't say a valid response after <see cref="Attempts"/>.</param>
-        /// <param name="choices"> The prompt choice values.</param>
+        /// <param name="values"> The prompt choice values.</param>
         /// <param name="attempts"> Maximum number of attempts.</param>
         /// <param name="promptStyler"> The prompt styler.</param>
-        /// <param name="descriptions">Descriptions for each prompt.</param>
+        /// <param name="titles">Descriptions for each prompt.</param>
         /// <param name="speak"> The Speak tag (SSML markup for text to speech).</param>
         /// <param name="retrySpeak"> What to display on retry Speak (SSML markup for text to speech).</param>
         /// <param name="recognizer"> Entity Recognizer to parse the message content.</param>
-        public PromptOptions(string prompt, string retry = null, string tooManyAttempts = null, IReadOnlyDictionary<T, IReadOnlyList<T>> choices = null, int attempts = 3, PromptStyler promptStyler = null, IReadOnlyList<string> descriptions = null, string speak = null, string retrySpeak = null, IPromptRecognizer recognizer = null)
+        public PromptOptions(string prompt, IReadOnlyList<string> titles = null, IReadOnlyDictionary<T, IReadOnlyList<T>> values = null, string retry = null, string tooManyAttempts = null, int attempts = 3, PromptStyler promptStyler = null, string speak = null, string retrySpeak = null, IPromptRecognizer recognizer = null)
         {
             SetField.NotNull(out this.Prompt, nameof(this.Prompt), prompt);
             this.Retry = retry;
@@ -214,9 +214,9 @@ namespace Microsoft.Bot.Builder.Dialogs
             this.RetrySpeak = retrySpeak;
             this.TooManyAttempts = tooManyAttempts ?? this.DefaultTooManyAttempts;
             this.Attempts = attempts;
-            this.Choices = choices;
+            this.Choices = values;
             this.Options = this.Choices?.Keys.ToList().AsReadOnly();
-            this.Descriptions = descriptions;
+            this.Descriptions = titles;
             this.DefaultRetry = prompt;
             this.DefaultRetrySpeak = speak;
             if (promptStyler == null)
@@ -362,7 +362,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="patterns">Yes and no alternatives for matching input where first dimension is either <see cref="PromptConfirm.Yes"/> or <see cref="PromptConfirm.No"/> and the arrays are alternative strings to match.</param>
         public static void Confirm(IDialogContext context, ResumeAfter<bool> resume, string prompt, string retry = null, int attempts = 3, PromptStyle promptStyle = PromptStyle.Auto, string[] options = null, string[][] patterns = null)
         {
-            Confirm(context, resume, new PromptOptions<string>(prompt, retry, attempts: attempts, options: options ?? PromptConfirm.Options, promptStyler: new PromptStyler(promptStyle: promptStyle)), patterns);
+            Confirm(context, resume, new PromptOptions<string>(prompt, values: default(IReadOnlyList<string>), retry: retry, attempts: attempts, promptStyler: new PromptStyler(promptStyle: promptStyle)));
         }
 
         /// <summary>
@@ -405,15 +405,15 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <summary>   Prompt for one of a set of choices. </summary>
         /// <param name="context">  The context. </param>
         /// <param name="resume">   Resume handler. </param>
-        /// <param name="options">  The possible options all of which must be convertible to a string.</param>
+        /// <param name="values">  The possible options all of which must be convertible to a string.</param>
         /// <param name="prompt">   The prompt to show to the user. </param>
         /// <param name="retry">    What to show on retry. </param>
         /// <param name="attempts"> The number of times to retry. </param>
         /// <param name="promptStyle"> Style of the prompt <see cref="PromptStyle" /> </param>
-        /// <param name="descriptions">Descriptions to display for choices.</param>
-        public static void Choice<T>(IDialogContext context, ResumeAfter<T> resume, IEnumerable<T> options, string prompt, string retry = null, int attempts = 3, PromptStyle promptStyle = PromptStyle.Auto, IEnumerable<string> descriptions = null)
+        /// <param name="titles">Titles to display for choices.</param>
+        public static void Choice<T>(IDialogContext context, ResumeAfter<T> resume, string prompt, IEnumerable<T> values, IEnumerable<string> titles = null, string retry = null, int attempts = 3, PromptStyle promptStyle = PromptStyle.Auto)
         {
-            Choice(context, resume, new PromptOptions<T>(prompt, retry, attempts: attempts, options: options.ToList(), promptStyler: new PromptStyler(promptStyle), descriptions: descriptions?.ToList()));
+            Choice(context, resume, new PromptOptions<T>(prompt, retry: retry, attempts: attempts, values: optionValues, promptStyler: new PromptStyler(promptStyle), titles: optionDescriptions));
         }
 
         /// <summary>   Prompt for one of a set of choices. </summary>
@@ -431,7 +431,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="minScore">(Optional) minimum score from 0.0 - 1.0 needed for a recognized choice to be considered a match. The default value is "0.4".</param>
         public static void Choice<T>(IDialogContext context, ResumeAfter<T> resume, IDictionary<T, IEnumerable<T>> choices, string prompt, string retry = null, int attempts = 3, PromptStyle promptStyle = PromptStyle.Auto, IEnumerable<string> descriptions = null, bool recognizeChoices = true, bool recognizeNumbers = true, bool recognizeOrdinals = true, double minScore = 0.4)
         {
-            Choice(context, resume, new PromptOptions<T>(prompt, retry, attempts: attempts, choices: choices.ToDictionary(x => x.Key, x => (IReadOnlyList<T>)x.Value.ToList().AsReadOnly()), promptStyler: new PromptStyler(promptStyle), descriptions: descriptions?.ToList()), recognizeChoices, recognizeNumbers, recognizeOrdinals, minScore: minScore);
+            Choice(context, resume, new PromptOptions<T>(prompt, values: default(IReadOnlyList<T>), retry: retry, attempts: attempts, promptStyler: new PromptStyler(promptStyle)), recognizeChoices, recognizeNumbers, recognizeOrdinals, minScore: minScore);
         }
 
         /// <summary>
@@ -477,7 +477,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             /// <param name="retry">    What to display on retry. </param>
             /// <param name="attempts"> Maximum number of attempts. </param>
             public PromptString(string prompt, string retry, int attempts)
-                : this(new PromptOptions<string>(prompt, retry, attempts: attempts, choices: null)) { }
+                : this(new PromptOptions<string>(prompt, values: default(IReadOnlyList<string>), retry: retry, attempts: attempts)) { }
 
             /// <summary>   Constructor for a prompt string dialog. </summary>
             /// <param name="promptOptions"> THe prompt options.</param>
@@ -557,7 +557,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             /// <param name="options">Names for yes and no  options.</param>
             /// <param name="patterns">Yes and no alternatives for matching input where first dimension is either <see cref="PromptConfirm.Yes"/> or <see cref="PromptConfirm.No"/> and the arrays are alternative strings to match.</param>
             public PromptConfirm(string prompt, string retry, int attempts, PromptStyle promptStyle = PromptStyle.Auto, string[] options = null, string[][] patterns = null)
-                : this(new PromptOptions<string>(prompt, retry, attempts: attempts, options: options ?? Options, promptStyler: new PromptStyler(promptStyle)), patterns)
+                : this(new PromptOptions<string>(prompt, values: default(IReadOnlyList<string>), retry: retry, attempts: attempts, promptStyler: new PromptStyler(promptStyle)))
             {
             }
 
@@ -611,7 +611,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             /// <param name="retry">    What to display on retry. </param>
             /// <param name="attempts"> Maximum number of attempts. </param>
             public PromptInt64(string prompt, string retry, int attempts)
-                : this(new PromptOptions<long>(prompt, retry, attempts: attempts, choices: null)) { }
+                : this(new PromptOptions<long>(prompt, values: default(IReadOnlyList<long>), retry: retry, attempts: attempts)) { }
 
             /// <summary>   Constructor for a prompt int64 dialog. </summary>
             /// <param name="promptOptions"> THe prompt options.</param>
@@ -642,7 +642,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             /// <param name="retry">    What to display on retry. </param>
             /// <param name="attempts"> Maximum number of attempts. </param>
             public PromptDouble(string prompt, string retry, int attempts)
-                : this(new PromptOptions<double>(prompt, retry, attempts: attempts, choices: null)) { }
+                : this(new PromptOptions<double>(prompt, values: default(IReadOnlyList<double>), retry: retry, attempts: attempts)) { }
 
             /// <summary>   Constructor for a prompt double dialog. </summary>
             /// <param name="promptOptions"> THe prompt options.</param>
@@ -685,7 +685,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             /// <param name="recognizeOrdinals">(Optional) if true, the prompt will attempt to recognize the selected value using the choices themselves. The default value is "true".</param>
             /// <param name="minScore">(Optional) minimum score from 0.0 - 1.0 needed for a recognized choice to be considered a match. The default value is "0.4".</param>
             public PromptChoice(IEnumerable<T> options, string prompt, string retry, int attempts, PromptStyle promptStyle = PromptStyle.Auto, IEnumerable<string> descriptions = null, bool recognizeChoices = true, bool recognizeNumbers = true, bool recognizeOrdinals = true, double minScore = 0.4)
-                : this(new PromptOptions<T>(prompt, retry, options: options.ToList(), attempts: attempts, promptStyler: new PromptStyler(promptStyle), descriptions: descriptions?.ToList()), recognizeChoices, recognizeNumbers, recognizeOrdinals, minScore)
+                : this(new PromptOptions<T>(prompt, values: default(IReadOnlyList<T>), retry: retry, attempts: attempts, promptStyler: new PromptStyler(promptStyle)))
             {
             }
 
@@ -701,7 +701,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             /// <param name="recognizeOrdinals">(Optional) if true, the prompt will attempt to recognize the selected value using the choices themselves. The default value is "true".</param>
             /// <param name="minScore">(Optional) minimum score from 0.0 - 1.0 needed for a recognized choice to be considered a match. The default value is "0.4".</param>
             public PromptChoice(IDictionary<T, IEnumerable<T>> choices, string prompt, string retry, int attempts, PromptStyle promptStyle = PromptStyle.Auto, IEnumerable<string> descriptions = null, bool recognizeChoices = true, bool recognizeNumbers = true, bool recognizeOrdinals = true, double minScore = 0.4)
-                : this(new PromptOptions<T>(prompt, retry, choices: choices.ToDictionary(x => x.Key, x => (IReadOnlyList<T>)x.Value.ToList().AsReadOnly()), attempts: attempts, promptStyler: new PromptStyler(promptStyle), descriptions: descriptions?.ToList()), recognizeChoices, recognizeNumbers, recognizeOrdinals, minScore)
+                : this(new PromptOptions<T>(prompt, values: default(IReadOnlyList<T>), retry: retry, attempts: attempts, promptStyler: new PromptStyler(promptStyle)), recognizeChoices, recognizeNumbers, recognizeOrdinals, minScore)
             {
             }
 
@@ -793,7 +793,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             /// <param name="attempts"> The optional content types the attachment type should be part of.</param>
             /// <param name="contentTypes"> The content types that is used to filter the attachments. Null implies any content type.</param>
             public PromptAttachment(string prompt, string retry, int attempts, IEnumerable<string> contentTypes = null)
-                : base(new PromptOptions<Attachment>(prompt, retry, attempts: attempts, choices: null))
+                : base(new PromptOptions<Attachment>(prompt, values: default(IReadOnlyList<Attachment>), retry: retry, attempts: attempts))
             {
                 this.ContentTypes = contentTypes ?? new List<string>();
             }

--- a/CSharp/Library/Microsoft.Bot.Builder/Resource/Resources.fr.resx
+++ b/CSharp/Library/Microsoft.Bot.Builder/Resource/Resources.fr.resx
@@ -87,7 +87,7 @@
     <value>Le choix actuel ("c"); courant; c; choix actuel</value>
   </data>
   <data name="MatchNo" xml:space="preserve">
-    <value>Non;pas;rien;2</value>
+    <value>non;pas;rien;2</value>
   </data>
   <data name="MatchNoPreference" xml:space="preserve">
     <value>Pas de préférence;non; pas; aucun; aucune;tout de même;ça m'est égal</value>

--- a/CSharp/Library/Microsoft.Bot.Connector.NetCore/Content/Microsoft.Bot.Connector.NetCore.XML
+++ b/CSharp/Library/Microsoft.Bot.Connector.NetCore/Content/Microsoft.Bot.Connector.NetCore.XML
@@ -44,6 +44,11 @@
             Signin button
             </summary>
         </member>
+        <member name="F:Microsoft.Bot.Connector.ActionTypes.Invoke">
+            <summary>
+            Invoke a command back to the bot
+            </summary>
+        </member>
         <member name="T:Microsoft.Bot.Connector.Activity">
             <summary>
             An Activity is the basic communication type for the Bot Framework 3.0 protocol
@@ -161,76 +166,7 @@
             Return an IInvokeActivity mask if this is an invoke activity
             </summary>
         </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.GetStateClient(Microsoft.Bot.Connector.MicrosoftAppCredentials,System.String,System.Net.Http.DelegatingHandler[])">
-            <summary>
-            Get StateClient appropriate for this activity
-            </summary>
-            <param name="credentials">credentials for bot to access state api</param>
-            <param name="serviceUrl">alternate serviceurl to use for state service</param>
-            <param name="handlers"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.GetStateClient(System.String,System.String,System.String,System.Net.Http.DelegatingHandler[])">
-            <summary>
-            Get StateClient appropriate for this activity
-            </summary>
-            <param name="microsoftAppId"></param>
-            <param name="microsoftAppPassword"></param>
-            <param name="serviceUrl">alternate serviceurl to use for state service</param>
-            <param name="handlers"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.HasContent">
-            <summary>
-            Check if the message has content
-            </summary>
-            <returns>Returns true if this message has any content to send</returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.GetMentions">
-            <summary>
-            Get mentions 
-            </summary>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.MentionsId(System.String)">
-            <summary>
-            Is there a mention of Id in the Text Property 
-            </summary>
-            <param name="id">ChannelAccount.Id</param>
-            <returns>true if this id is mentioned in the text</returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.MentionsRecipient">
-            <summary>
-            Is there a mention of Recipient.Id in the Text Property 
-            </summary>
-            <returns>true if this id is mentioned in the text</returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.RemoveRecipientMention">
-            <summary>
-            Remove recipient mention text from Text property
-            </summary>
-            <returns>new .Text property value</returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.RemoveMentionText(System.String)">
-            <summary>
-            Replace any mention text for given id from Text property
-            </summary>
-            <param name="id">id to match</param>
-            <returns>new .Text property value</returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.GetChannelData``1">
-            <summary>
-            Get channeldata as typed structure
-            </summary>
-            <typeparam name="TypeT">type to use</typeparam>
-            <returns>typed object or default(TypeT)</returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.GetActivityType">
-            <summary>
-            Return the "major" portion of the activity
-            </summary>
-            <returns>normalized major portion of the activity, aka message/... will return "message"</returns>
-        </member>
+        <!-- Badly formed XML comment ignored for member "M:Microsoft.Bot.Connector.Activity.GetActivityType(System.String)" -->
         <member name="M:Microsoft.Bot.Connector.Activity.#ctor">
             <summary>
             Initializes a new instance of the Activity class.
@@ -397,6 +333,96 @@
             <summary>
             Code indicating why the conversation has ended
             </summary>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.GetStateClient(Microsoft.Bot.Connector.IActivity,Microsoft.Bot.Connector.MicrosoftAppCredentials,System.String,System.Net.Http.DelegatingHandler[])">
+            <summary>
+            Get StateClient appropriate for this activity
+            </summary>
+            <param name="credentials">credentials for bot to access state api</param>
+            <param name="serviceUrl">alternate serviceurl to use for state service</param>
+            <param name="handlers"></param>
+            <param name="activity"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.GetStateClient(Microsoft.Bot.Connector.IActivity,System.String,System.String,System.String,System.Net.Http.DelegatingHandler[])">
+            <summary>
+            Get StateClient appropriate for this activity
+            </summary>
+            <param name="microsoftAppId"></param>
+            <param name="microsoftAppPassword"></param>
+            <param name="serviceUrl">alternate serviceurl to use for state service</param>
+            <param name="handlers"></param>
+            <param name="activity"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.GetActivityType(Microsoft.Bot.Connector.IActivity)">
+            <summary>
+            Return the "major" portion of the activity
+            </summary>
+            <param name="activity"></param>
+            <returns>normalized major portion of the activity, aka message/... will return "message"</returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.GetChannelData``1(Microsoft.Bot.Connector.IActivity)">
+            <summary>
+            Get channeldata as typed structure
+            </summary>
+            <param name="activity"></param>
+            <typeparam name="TypeT">type to use</typeparam>
+            <returns>typed object or default(TypeT)</returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.TryGetChannelData``1(Microsoft.Bot.Connector.IActivity,``0@)">
+            <summary>
+            Get channeldata as typed structure
+            </summary>
+            <param name="activity"></param>
+            <typeparam name="TypeT">type to use</typeparam>
+            <param name="instance">The resulting instance, if possible</param>
+            <returns>
+            <c>true</c> if value of <seealso cref="P:Microsoft.Bot.Connector.IActivity.ChannelData"/> was coerceable to <typeparamref name="TypeT"/>, <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.HasContent(Microsoft.Bot.Connector.IMessageActivity)">
+            <summary>
+            Check if the message has content
+            </summary>
+            <returns>Returns true if this message has any content to send</returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.GetMentions(Microsoft.Bot.Connector.IMessageActivity)">
+            <summary>
+            Get mentions 
+            </summary>
+            <param name="activity"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.MentionsId(Microsoft.Bot.Connector.IMessageActivity,System.String)">
+            <summary>
+            Is there a mention of Id in the Text Property 
+            </summary>
+            <param name="id">ChannelAccount.Id</param>
+            <param name="activity"></param>
+            <returns>true if this id is mentioned in the text</returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.MentionsRecipient(Microsoft.Bot.Connector.IMessageActivity)">
+            <summary>
+            Is there a mention of Recipient.Id in the Text Property 
+            </summary>
+            <param name="activity"></param>
+            <returns>true if this id is mentioned in the text</returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.RemoveRecipientMention(Microsoft.Bot.Connector.IMessageActivity)">
+            <summary>
+            Remove recipient mention text from Text property
+            </summary>
+            <param name="activity"></param>
+            <returns>new .Text property value</returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.RemoveMentionText(Microsoft.Bot.Connector.IMessageActivity,System.String)">
+            <summary>
+            Replace any mention text for given id from Text property
+            </summary>
+            <param name="id">id to match</param>
+            <param name="activity"></param>
+            <returns>new .Text property value</returns>
         </member>
         <member name="T:Microsoft.Bot.Connector.ActivityTypes">
             <summary>
@@ -2608,7 +2634,7 @@
         </member>
         <member name="P:Microsoft.Bot.Connector.CardAction.Type">
             <summary>
-            Defines the type of action implemented by this button.
+            Defines the type of action implemented by this button. Defaults to <see cref="F:Microsoft.Bot.Connector.ActionTypes.ImBack"/>
             </summary>
         </member>
         <member name="P:Microsoft.Bot.Connector.CardAction.Title">
@@ -3567,13 +3593,6 @@
             <summary>
             True if this activity has text, attachments, or channelData
             </summary>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.IMessageActivity.GetChannelData``1">
-            <summary>
-            Get channeldata as typed structure
-            </summary>
-            <typeparam name="TypeT">type to use</typeparam>
-            <returns>typed object or default(TypeT)</returns>
         </member>
         <member name="M:Microsoft.Bot.Connector.IMessageActivity.GetMentions">
             <summary>

--- a/CSharp/Library/Microsoft.Bot.Connector.NetFramework/BotAuthentication.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.NetFramework/BotAuthentication.cs
@@ -1,14 +1,9 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
 
@@ -60,7 +55,7 @@ namespace Microsoft.Bot.Connector
 
 
 
-        public override async Task OnActionExecutingAsync(HttpActionContext actionContext, CancellationToken cancellationToken)
+        public override async Task OnActionExecutingAsync(HttpActionContext actionContext, CancellationToken cancellationToken = default(CancellationToken))
         {
             var provider = this.GetCredentialProvider();
             var botAuthenticator = new BotAuthenticator(provider, OpenIdConfigurationUrl, DisableEmulatorTokens);
@@ -115,7 +110,7 @@ namespace Microsoft.Bot.Connector
             {
                 // if we have raw values
                 credentialProvider = new StaticCredentialProvider(MicrosoftAppId, MicrosoftAppPassword);
-             
+
             }
             else
             {

--- a/CSharp/Library/Microsoft.Bot.Connector.NetFramework/Content/Microsoft.Bot.Connector.xml
+++ b/CSharp/Library/Microsoft.Bot.Connector.NetFramework/Content/Microsoft.Bot.Connector.xml
@@ -81,6 +81,11 @@
             Signin button
             </summary>
         </member>
+        <member name="F:Microsoft.Bot.Connector.ActionTypes.Invoke">
+            <summary>
+            Invoke a command back to the bot
+            </summary>
+        </member>
         <member name="T:Microsoft.Bot.Connector.Activity">
             <summary>
             An Activity is the basic communication type for the Bot Framework 3.0 protocol
@@ -198,6 +203,7 @@
             Return an IInvokeActivity mask if this is an invoke activity
             </summary>
         </member>
+        <!-- Badly formed XML comment ignored for member "M:Microsoft.Bot.Connector.Activity.GetActivityType(System.String)" -->
         <member name="M:Microsoft.Bot.Connector.Activity.#ctor">
             <summary>
             Initializes a new instance of the Activity class.
@@ -400,6 +406,17 @@
             <param name="activity"></param>
             <typeparam name="TypeT">type to use</typeparam>
             <returns>typed object or default(TypeT)</returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.TryGetChannelData``1(Microsoft.Bot.Connector.IActivity,``0@)">
+            <summary>
+            Get channeldata as typed structure
+            </summary>
+            <param name="activity"></param>
+            <typeparam name="TypeT">type to use</typeparam>
+            <param name="instance">The resulting instance, if possible</param>
+            <returns>
+            <c>true</c> if value of <seealso cref="P:Microsoft.Bot.Connector.IActivity.ChannelData"/> was coerceable to <typeparamref name="TypeT"/>, <c>false</c> otherwise.
+            </returns>
         </member>
         <member name="M:Microsoft.Bot.Connector.ActivityExtensions.HasContent(Microsoft.Bot.Connector.IMessageActivity)">
             <summary>
@@ -2654,7 +2671,7 @@
         </member>
         <member name="P:Microsoft.Bot.Connector.CardAction.Type">
             <summary>
-            Defines the type of action implemented by this button.
+            Defines the type of action implemented by this button. Defaults to <see cref="F:Microsoft.Bot.Connector.ActionTypes.ImBack"/>
             </summary>
         </member>
         <member name="P:Microsoft.Bot.Connector.CardAction.Title">
@@ -3613,13 +3630,6 @@
             <summary>
             True if this activity has text, attachments, or channelData
             </summary>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.IMessageActivity.GetChannelData``1">
-            <summary>
-            Get channeldata as typed structure
-            </summary>
-            <typeparam name="TypeT">type to use</typeparam>
-            <returns>typed object or default(TypeT)</returns>
         </member>
         <member name="M:Microsoft.Bot.Connector.IMessageActivity.GetMentions">
             <summary>

--- a/CSharp/Library/Microsoft.Bot.Connector.NetFramework/Content/Microsoft.Bot.Connector.xml
+++ b/CSharp/Library/Microsoft.Bot.Connector.NetFramework/Content/Microsoft.Bot.Connector.xml
@@ -198,76 +198,6 @@
             Return an IInvokeActivity mask if this is an invoke activity
             </summary>
         </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.GetStateClient(Microsoft.Bot.Connector.MicrosoftAppCredentials,System.String,System.Net.Http.DelegatingHandler[])">
-            <summary>
-            Get StateClient appropriate for this activity
-            </summary>
-            <param name="credentials">credentials for bot to access state api</param>
-            <param name="serviceUrl">alternate serviceurl to use for state service</param>
-            <param name="handlers"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.GetStateClient(System.String,System.String,System.String,System.Net.Http.DelegatingHandler[])">
-            <summary>
-            Get StateClient appropriate for this activity
-            </summary>
-            <param name="microsoftAppId"></param>
-            <param name="microsoftAppPassword"></param>
-            <param name="serviceUrl">alternate serviceurl to use for state service</param>
-            <param name="handlers"></param>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.HasContent">
-            <summary>
-            Check if the message has content
-            </summary>
-            <returns>Returns true if this message has any content to send</returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.GetMentions">
-            <summary>
-            Get mentions 
-            </summary>
-            <returns></returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.MentionsId(System.String)">
-            <summary>
-            Is there a mention of Id in the Text Property 
-            </summary>
-            <param name="id">ChannelAccount.Id</param>
-            <returns>true if this id is mentioned in the text</returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.MentionsRecipient">
-            <summary>
-            Is there a mention of Recipient.Id in the Text Property 
-            </summary>
-            <returns>true if this id is mentioned in the text</returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.RemoveRecipientMention">
-            <summary>
-            Remove recipient mention text from Text property
-            </summary>
-            <returns>new .Text property value</returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.RemoveMentionText(System.String)">
-            <summary>
-            Replace any mention text for given id from Text property
-            </summary>
-            <param name="id">id to match</param>
-            <returns>new .Text property value</returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.GetChannelData``1">
-            <summary>
-            Get channeldata as typed structure
-            </summary>
-            <typeparam name="TypeT">type to use</typeparam>
-            <returns>typed object or default(TypeT)</returns>
-        </member>
-        <member name="M:Microsoft.Bot.Connector.Activity.GetActivityType">
-            <summary>
-            Return the "major" portion of the activity
-            </summary>
-            <returns>normalized major portion of the activity, aka message/... will return "message"</returns>
-        </member>
         <member name="M:Microsoft.Bot.Connector.Activity.#ctor">
             <summary>
             Initializes a new instance of the Activity class.
@@ -434,6 +364,85 @@
             <summary>
             Code indicating why the conversation has ended
             </summary>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.GetStateClient(Microsoft.Bot.Connector.IActivity,Microsoft.Bot.Connector.MicrosoftAppCredentials,System.String,System.Net.Http.DelegatingHandler[])">
+            <summary>
+            Get StateClient appropriate for this activity
+            </summary>
+            <param name="credentials">credentials for bot to access state api</param>
+            <param name="serviceUrl">alternate serviceurl to use for state service</param>
+            <param name="handlers"></param>
+            <param name="activity"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.GetStateClient(Microsoft.Bot.Connector.IActivity,System.String,System.String,System.String,System.Net.Http.DelegatingHandler[])">
+            <summary>
+            Get StateClient appropriate for this activity
+            </summary>
+            <param name="microsoftAppId"></param>
+            <param name="microsoftAppPassword"></param>
+            <param name="serviceUrl">alternate serviceurl to use for state service</param>
+            <param name="handlers"></param>
+            <param name="activity"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.GetActivityType(Microsoft.Bot.Connector.IActivity)">
+            <summary>
+            Return the "major" portion of the activity
+            </summary>
+            <param name="activity"></param>
+            <returns>normalized major portion of the activity, aka message/... will return "message"</returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.GetChannelData``1(Microsoft.Bot.Connector.IActivity)">
+            <summary>
+            Get channeldata as typed structure
+            </summary>
+            <param name="activity"></param>
+            <typeparam name="TypeT">type to use</typeparam>
+            <returns>typed object or default(TypeT)</returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.HasContent(Microsoft.Bot.Connector.IMessageActivity)">
+            <summary>
+            Check if the message has content
+            </summary>
+            <returns>Returns true if this message has any content to send</returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.GetMentions(Microsoft.Bot.Connector.IMessageActivity)">
+            <summary>
+            Get mentions 
+            </summary>
+            <param name="activity"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.MentionsId(Microsoft.Bot.Connector.IMessageActivity,System.String)">
+            <summary>
+            Is there a mention of Id in the Text Property 
+            </summary>
+            <param name="id">ChannelAccount.Id</param>
+            <param name="activity"></param>
+            <returns>true if this id is mentioned in the text</returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.MentionsRecipient(Microsoft.Bot.Connector.IMessageActivity)">
+            <summary>
+            Is there a mention of Recipient.Id in the Text Property 
+            </summary>
+            <param name="activity"></param>
+            <returns>true if this id is mentioned in the text</returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.RemoveRecipientMention(Microsoft.Bot.Connector.IMessageActivity)">
+            <summary>
+            Remove recipient mention text from Text property
+            </summary>
+            <param name="activity"></param>
+            <returns>new .Text property value</returns>
+        </member>
+        <member name="M:Microsoft.Bot.Connector.ActivityExtensions.RemoveMentionText(Microsoft.Bot.Connector.IMessageActivity,System.String)">
+            <summary>
+            Replace any mention text for given id from Text property
+            </summary>
+            <param name="id">id to match</param>
+            <param name="activity"></param>
+            <returns>new .Text property value</returns>
         </member>
         <member name="T:Microsoft.Bot.Connector.ActivityTypes">
             <summary>

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ActionTypes.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ActionTypes.cs
@@ -47,5 +47,10 @@ namespace Microsoft.Bot.Connector
         /// Signin button
         /// </summary>
         public const string Signin = "signin";
+
+        /// <summary>
+        /// Invoke a command back to the bot
+        /// </summary>
+        public const string Invoke = "invoke";
     }
 }

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ActivityEx.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ActivityEx.cs
@@ -51,8 +51,6 @@ namespace Microsoft.Bot.Connector
             reply.Conversation = new ConversationAccount(isGroup: this.Conversation.IsGroup, id: this.Conversation.Id, name: this.Conversation.Name);
             reply.Text = text ?? String.Empty;
             reply.Locale = locale ?? this.Locale;
-            reply.Attachments = new List<Attachment>();
-            reply.Entities = new List<Entity>();
             return reply;
         }
 

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ActivityEx.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ActivityEx.cs
@@ -148,132 +148,6 @@ namespace Microsoft.Bot.Connector
         /// </summary>
         public IInvokeActivity AsInvokeActivity() { return IsActivity(ActivityTypes.Invoke) ? this : null; }
 
-        /// <summary>
-        /// Get StateClient appropriate for this activity
-        /// </summary>
-        /// <param name="credentials">credentials for bot to access state api</param>
-        /// <param name="serviceUrl">alternate serviceurl to use for state service</param>
-        /// <param name="handlers"></param>
-        /// <returns></returns>
-        public StateClient GetStateClient(MicrosoftAppCredentials credentials, string serviceUrl = null, params DelegatingHandler[] handlers)
-        {
-            bool useServiceUrl = (this.ChannelId == "emulator");
-            if (useServiceUrl)
-                return new StateClient(new Uri(this.ServiceUrl), credentials: credentials, handlers: handlers);
-
-            if (serviceUrl != null)
-                return new StateClient(new Uri(serviceUrl), credentials: credentials, handlers: handlers);
-
-            return new StateClient(credentials, true, handlers);
-        }
-
-        /// <summary>
-        /// Get StateClient appropriate for this activity
-        /// </summary>
-        /// <param name="microsoftAppId"></param>
-        /// <param name="microsoftAppPassword"></param>
-        /// <param name="serviceUrl">alternate serviceurl to use for state service</param>
-        /// <param name="handlers"></param>
-        /// <returns></returns>
-        public StateClient GetStateClient(string microsoftAppId = null, string microsoftAppPassword = null, string serviceUrl = null, params DelegatingHandler[] handlers)
-        {
-            return GetStateClient(new MicrosoftAppCredentials(microsoftAppId, microsoftAppPassword), serviceUrl, handlers);
-        }
-
-        /// <summary>
-        /// Check if the message has content
-        /// </summary>
-        /// <returns>Returns true if this message has any content to send</returns>
-        public bool HasContent()
-        {
-            if (!String.IsNullOrWhiteSpace(this.Text))
-                return true;
-
-            if (!String.IsNullOrWhiteSpace(this.Summary))
-                return true;
-
-            if (this.Attachments != null && this.Attachments.Any())
-                return true;
-
-            if (this.ChannelData != null)
-                return true;
-
-            return false;
-        }
-
-        /// <summary>
-        /// Get mentions 
-        /// </summary>
-        /// <returns></returns>
-        public Mention[] GetMentions()
-        {
-            return this.Entities?.Where(entity => String.Compare(entity.Type, "mention", ignoreCase: true) == 0).Select(e => e.Properties.ToObject<Mention>()).ToArray() ?? new Mention[0];
-        }
-
-        /// <summary>
-        /// Is there a mention of Id in the Text Property 
-        /// </summary>
-        /// <param name="id">ChannelAccount.Id</param>
-        /// <returns>true if this id is mentioned in the text</returns>
-        public bool MentionsId(string id)
-        {
-            return this.GetMentions().Where(mention => mention.Mentioned.Id == id).Any();
-        }
-
-        /// <summary>
-        /// Is there a mention of Recipient.Id in the Text Property 
-        /// </summary>
-        /// <returns>true if this id is mentioned in the text</returns>
-        public bool MentionsRecipient()
-        {
-            return this.GetMentions().Where(mention => mention.Mentioned.Id == this.Recipient.Id).Any();
-        }
-
-        /// <summary>
-        /// Remove recipient mention text from Text property
-        /// </summary>
-        /// <returns>new .Text property value</returns>
-        public string RemoveRecipientMention()
-        {
-            return RemoveMentionText(this.Recipient.Id);
-        }
-
-        /// <summary>
-        /// Replace any mention text for given id from Text property
-        /// </summary>
-        /// <param name="id">id to match</param>
-        /// <returns>new .Text property value</returns>
-        public string RemoveMentionText(string id)
-        {
-            foreach (var mention in this.GetMentions().Where(mention => mention.Mentioned.Id == id))
-            {
-                Text = Regex.Replace(Text, mention.Text, "", RegexOptions.IgnoreCase);
-            }
-            return this.Text;
-        }
-
-        /// <summary>
-        /// Get channeldata as typed structure
-        /// </summary>
-        /// <typeparam name="TypeT">type to use</typeparam>
-        /// <returns>typed object or default(TypeT)</returns>
-        public TypeT GetChannelData<TypeT>()
-        {
-            if (this.ChannelData == null)
-                return default(TypeT);
-            return ((JObject)this.ChannelData).ToObject<TypeT>();
-        }
-
-        /// <summary>
-        /// Return the "major" portion of the activity
-        /// </summary>
-        /// <returns>normalized major portion of the activity, aka message/... will return "message"</returns>
-        public string GetActivityType()
-        {
-            var type = this.Type.Split('/').First();
-            return GetActivityType(type);
-        }
-
         public static string GetActivityType(string type)
         {
             if (String.Equals(type, ActivityTypes.Message, StringComparison.OrdinalIgnoreCase))
@@ -295,6 +169,159 @@ namespace Microsoft.Bot.Connector
                 return ActivityTypes.Ping;
 
             return $"{Char.ToLower(type[0])}{type.Substring(1)}";
+        }
+
+        public bool HasContent()
+        {
+            // hit the extension method
+            return ((IMessageActivity)this).HasContent();
+        }
+
+        public TypeT GetChannelData<TypeT>()
+        {
+            // hit the extension method
+            return ((IActivity)this).GetChannelData<TypeT>();
+        }
+
+        public Mention[] GetMentions()
+        {
+            // hit the extension method
+            return ((IMessageActivity)this).GetMentions();
+        }
+    }
+
+    public static class ActivityExtensions
+    {
+        /// <summary>
+        /// Get StateClient appropriate for this activity
+        /// </summary>
+        /// <param name="credentials">credentials for bot to access state api</param>
+        /// <param name="serviceUrl">alternate serviceurl to use for state service</param>
+        /// <param name="handlers"></param>
+        /// <param name="activity"></param>
+        /// <returns></returns>
+        public static StateClient GetStateClient(this IActivity activity, MicrosoftAppCredentials credentials, string serviceUrl = null, params DelegatingHandler[] handlers)
+        {
+            bool useServiceUrl = (activity.ChannelId == "emulator");
+            if (useServiceUrl)
+                return new StateClient(new Uri(activity.ServiceUrl), credentials: credentials, handlers: handlers);
+
+            if (serviceUrl != null)
+                return new StateClient(new Uri(serviceUrl), credentials: credentials, handlers: handlers);
+
+            return new StateClient(credentials, true, handlers);
+        }
+
+        /// <summary>
+        /// Get StateClient appropriate for this activity
+        /// </summary>
+        /// <param name="microsoftAppId"></param>
+        /// <param name="microsoftAppPassword"></param>
+        /// <param name="serviceUrl">alternate serviceurl to use for state service</param>
+        /// <param name="handlers"></param>
+        /// <param name="activity"></param>
+        /// <returns></returns>
+        public static StateClient GetStateClient(this IActivity activity, string microsoftAppId = null, string microsoftAppPassword = null, string serviceUrl = null, params DelegatingHandler[] handlers) => GetStateClient(activity, new MicrosoftAppCredentials(microsoftAppId, microsoftAppPassword), serviceUrl, handlers);
+
+        /// <summary>
+        /// Return the "major" portion of the activity
+        /// </summary>
+        /// <param name="activity"></param>
+        /// <returns>normalized major portion of the activity, aka message/... will return "message"</returns>
+        public static string GetActivityType(this IActivity activity)
+        {
+            var type = activity.Type.Split('/').First();
+            return Activity.GetActivityType(type);
+        }
+
+        /// <summary>
+        /// Get channeldata as typed structure
+        /// </summary>
+        /// <param name="activity"></param>
+        /// <typeparam name="TypeT">type to use</typeparam>
+        /// <returns>typed object or default(TypeT)</returns>
+        public static TypeT GetChannelData<TypeT>(this IActivity activity)
+        {
+            if (activity.ChannelData == null)
+                return default(TypeT);
+            return ((JObject)activity.ChannelData).ToObject<TypeT>();
+        }
+
+        /// <summary>
+        /// Check if the message has content
+        /// </summary>
+        /// <returns>Returns true if this message has any content to send</returns>
+        public static bool HasContent(this IMessageActivity activity)
+        {
+            if (!String.IsNullOrWhiteSpace(activity.Text))
+                return true;
+
+            if (!String.IsNullOrWhiteSpace(activity.Summary))
+                return true;
+
+            if (activity.Attachments != null && activity.Attachments.Any())
+                return true;
+
+            if (activity.ChannelData != null)
+                return true;
+
+            return false;
+        }
+
+        /// <summary>
+        /// Get mentions 
+        /// </summary>
+        /// <param name="activity"></param>
+        /// <returns></returns>
+        public static Mention[] GetMentions(this IMessageActivity activity)
+        {
+            return activity.Entities?.Where(entity => String.Compare(entity.Type, "mention", ignoreCase: true) == 0).Select(e => e.Properties.ToObject<Mention>()).ToArray() ?? new Mention[0];
+        }
+
+        /// <summary>
+        /// Is there a mention of Id in the Text Property 
+        /// </summary>
+        /// <param name="id">ChannelAccount.Id</param>
+        /// <param name="activity"></param>
+        /// <returns>true if this id is mentioned in the text</returns>
+        public static bool MentionsId(this IMessageActivity activity, string id)
+        {
+            return activity.GetMentions().Where(mention => mention.Mentioned.Id == id).Any();
+        }
+
+        /// <summary>
+        /// Is there a mention of Recipient.Id in the Text Property 
+        /// </summary>
+        /// <param name="activity"></param>
+        /// <returns>true if this id is mentioned in the text</returns>
+        public static bool MentionsRecipient(this IMessageActivity activity)
+        {
+            return activity.GetMentions().Where(mention => mention.Mentioned.Id == activity.Recipient.Id).Any();
+        }
+
+        /// <summary>
+        /// Remove recipient mention text from Text property
+        /// </summary>
+        /// <param name="activity"></param>
+        /// <returns>new .Text property value</returns>
+        public static string RemoveRecipientMention(this IMessageActivity activity)
+        {
+            return activity.RemoveMentionText(activity.Recipient.Id);
+        }
+
+        /// <summary>
+        /// Replace any mention text for given id from Text property
+        /// </summary>
+        /// <param name="id">id to match</param>
+        /// <param name="activity"></param>
+        /// <returns>new .Text property value</returns>
+        public static string RemoveMentionText(this IMessageActivity activity, string id)
+        {
+            foreach (var mention in activity.GetMentions().Where(mention => mention.Mentioned.Id == id))
+            {
+                activity.Text = Regex.Replace(activity.Text, mention.Text, "", RegexOptions.IgnoreCase);
+            }
+            return activity.Text;
         }
     }
 }

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ActivityEx.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ActivityEx.cs
@@ -146,6 +146,7 @@ namespace Microsoft.Bot.Connector
         /// </summary>
         public IInvokeActivity AsInvokeActivity() { return IsActivity(ActivityTypes.Invoke) ? this : null; }
 
+        /// <summary>
         public static string GetActivityType(string type)
         {
             if (String.Equals(type, ActivityTypes.Message, StringComparison.OrdinalIgnoreCase))
@@ -173,12 +174,6 @@ namespace Microsoft.Bot.Connector
         {
             // hit the extension method
             return ((IMessageActivity)this).HasContent();
-        }
-
-        public TypeT GetChannelData<TypeT>()
-        {
-            // hit the extension method
-            return ((IActivity)this).GetChannelData<TypeT>();
         }
 
         public Mention[] GetMentions()
@@ -244,6 +239,38 @@ namespace Microsoft.Bot.Connector
                 return default(TypeT);
             return ((JObject)activity.ChannelData).ToObject<TypeT>();
         }
+
+
+        /// <summary>
+        /// Get channeldata as typed structure
+        /// </summary>
+        /// <param name="activity"></param>
+        /// <typeparam name="TypeT">type to use</typeparam>
+        /// <param name="instance">The resulting instance, if possible</param>
+        /// <returns>
+        /// <c>true</c> if value of <seealso cref="IActivity.ChannelData"/> was coerceable to <typeparamref name="TypeT"/>, <c>false</c> otherwise.
+        /// </returns>
+        public static bool TryGetChannelData<TypeT>(this IActivity activity,
+            out TypeT instance)
+        {
+            instance = default(TypeT);
+
+            try
+            {
+                if (activity.ChannelData == null)
+                {
+                    return false;
+                }
+
+                instance = GetChannelData<TypeT>(activity);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
 
         /// <summary>
         /// Check if the message has content

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/BotAuthenticator.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/BotAuthenticator.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Bot.Connector
         }
         
         public async Task<IdentityToken> TryAuthenticateAsync(string scheme, string token,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             // then auth is disabled
             if (await this.credentialProvider.IsAuthenticationDisabledAsync())

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/Activity.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/Activity.cs
@@ -133,13 +133,13 @@ namespace Microsoft.Bot.Connector
         /// Array of address added
         /// </summary>
         [JsonProperty(PropertyName = "membersAdded")]
-        public IList<ChannelAccount> MembersAdded { get; set; }
+        public IList<ChannelAccount> MembersAdded { get; set; } = new ChannelAccount[0];
 
         /// <summary>
         /// Array of addresses removed
         /// </summary>
         [JsonProperty(PropertyName = "membersRemoved")]
-        public IList<ChannelAccount> MembersRemoved { get; set; }
+        public IList<ChannelAccount> MembersRemoved { get; set; } = new ChannelAccount[0];
 
         /// <summary>
         /// Conversations new topic name
@@ -195,14 +195,14 @@ namespace Microsoft.Bot.Connector
         /// Attachments
         /// </summary>
         [JsonProperty(PropertyName = "attachments")]
-        public IList<Attachment> Attachments { get; set; }
+        public IList<Attachment> Attachments { get; set; } = new Attachment[0];
 
         /// <summary>
         /// Collection of Entity objects, each of which contains metadata
         /// about this activity. Each Entity object is typed.
         /// </summary>
         [JsonProperty(PropertyName = "entities")]
-        public IList<Entity> Entities { get; set; }
+        public IList<Entity> Entities { get; set; } = new Entity[0];
 
         /// <summary>
         /// Channel-specific payload

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/AnimationCard.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/AnimationCard.cs
@@ -65,13 +65,13 @@ namespace Microsoft.Bot.Connector
         /// Array of media Url objects
         /// </summary>
         [JsonProperty(PropertyName = "media")]
-        public IList<MediaUrl> Media { get; set; }
+        public IList<MediaUrl> Media { get; set; } = new MediaUrl[0];
 
         /// <summary>
         /// Set of actions applicable to the current card
         /// </summary>
         [JsonProperty(PropertyName = "buttons")]
-        public IList<CardAction> Buttons { get; set; }
+        public IList<CardAction> Buttons { get; set; } = new CardAction[0];
 
         /// <summary>
         /// Is it OK for this content to be shareable with others

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/AudioCard.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/AudioCard.cs
@@ -73,13 +73,13 @@ namespace Microsoft.Bot.Connector
         /// Array of media Url objects
         /// </summary>
         [JsonProperty(PropertyName = "media")]
-        public IList<MediaUrl> Media { get; set; }
+        public IList<MediaUrl> Media { get; set; } = new MediaUrl[0];
 
         /// <summary>
         /// Set of actions applicable to the current card
         /// </summary>
         [JsonProperty(PropertyName = "buttons")]
-        public IList<CardAction> Buttons { get; set; }
+        public IList<CardAction> Buttons { get; set; } = new CardAction[0];
 
         /// <summary>
         /// Is it OK for this content to be shareable with others

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/CardAction.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/CardAction.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Initializes a new instance of the CardAction class.
         /// </summary>
-        public CardAction(string type = default(string), string title = default(string), string image = default(string), object value = default(object))
+        public CardAction(string type, string title = default(string), string image = default(string), object value = default(object))
         {
             Type = type;
             Title = title;
@@ -33,10 +33,10 @@ namespace Microsoft.Bot.Connector
         }
 
         /// <summary>
-        /// Defines the type of action implemented by this button.
+        /// Defines the type of action implemented by this button. Defaults to <see cref="ActionTypes.ImBack"/>
         /// </summary>
         [JsonProperty(PropertyName = "type")]
-        public string Type { get; set; }
+        public string Type { get; set; } = ActionTypes.ImBack;
 
         /// <summary>
         /// Text description which appear on the button.

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/HeroCard.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/HeroCard.cs
@@ -56,19 +56,18 @@ namespace Microsoft.Bot.Connector
         /// Array of images for the card
         /// </summary>
         [JsonProperty(PropertyName = "images")]
-        public IList<CardImage> Images { get; set; }
+        public IList<CardImage> Images { get; set; } = new CardImage[0];
 
         /// <summary>
         /// Set of actions applicable to the current card
         /// </summary>
         [JsonProperty(PropertyName = "buttons")]
-        public IList<CardAction> Buttons { get; set; }
+        public IList<CardAction> Buttons { get; set; } = new CardAction[0];
 
         /// <summary>
         /// This action will be activated when user taps on the card itself
         /// </summary>
         [JsonProperty(PropertyName = "tap")]
         public CardAction Tap { get; set; }
-
     }
 }

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/ReceiptCard.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/ReceiptCard.cs
@@ -46,13 +46,13 @@ namespace Microsoft.Bot.Connector
         /// Array of Receipt Items
         /// </summary>
         [JsonProperty(PropertyName = "items")]
-        public IList<ReceiptItem> Items { get; set; }
+        public IList<ReceiptItem> Items { get; set; } = new ReceiptItem[0];
 
         /// <summary>
         /// Array of Fact Objects   Array of key-value pairs.
         /// </summary>
         [JsonProperty(PropertyName = "facts")]
-        public IList<Fact> Facts { get; set; }
+        public IList<Fact> Facts { get; set; } = new Fact[0];
 
         /// <summary>
         /// This action will be activated when user taps on the card
@@ -82,7 +82,7 @@ namespace Microsoft.Bot.Connector
         /// Set of actions applicable to the current card
         /// </summary>
         [JsonProperty(PropertyName = "buttons")]
-        public IList<CardAction> Buttons { get; set; }
+        public IList<CardAction> Buttons { get; set; } = new CardAction[0];
 
     }
 }

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/SigninCard.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/SigninCard.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Bot.Connector
         /// Action to use to perform signin
         /// </summary>
         [JsonProperty(PropertyName = "buttons")]
-        public IList<CardAction> Buttons { get; set; }
+        public IList<CardAction> Buttons { get; set; } = new CardAction[0];
 
     }
 }

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/ThumbnailCard.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/ThumbnailCard.cs
@@ -56,13 +56,13 @@ namespace Microsoft.Bot.Connector
         /// Array of images for the card
         /// </summary>
         [JsonProperty(PropertyName = "images")]
-        public IList<CardImage> Images { get; set; }
+        public IList<CardImage> Images { get; set; } = new CardImage[0];
 
         /// <summary>
         /// Set of actions applicable to the current card
         /// </summary>
         [JsonProperty(PropertyName = "buttons")]
-        public IList<CardAction> Buttons { get; set; }
+        public IList<CardAction> Buttons { get; set; } = new CardAction[0];
 
         /// <summary>
         /// This action will be activated when user taps on the card itself

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/VideoCard.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/VideoCard.cs
@@ -72,13 +72,13 @@ namespace Microsoft.Bot.Connector
         /// Array of media Url objects
         /// </summary>
         [JsonProperty(PropertyName = "media")]
-        public IList<MediaUrl> Media { get; set; }
+        public IList<MediaUrl> Media { get; set; } = new MediaUrl[0];
 
         /// <summary>
         /// Set of actions applicable to the current card
         /// </summary>
         [JsonProperty(PropertyName = "buttons")]
-        public IList<CardAction> Buttons { get; set; }
+        public IList<CardAction> Buttons { get; set; } = new CardAction[0];
 
         /// <summary>
         /// Is it OK for this content to be shareable with others

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/IMessageActivity.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/IMessageActivity.cs
@@ -68,13 +68,6 @@ namespace Microsoft.Bot.Connector
         bool HasContent();
 
         /// <summary>
-        /// Get channeldata as typed structure
-        /// </summary>
-        /// <typeparam name="TypeT">type to use</typeparam>
-        /// <returns>typed object or default(TypeT)</returns>
-        TypeT GetChannelData<TypeT>();
-
-        /// <summary>
         /// Get mentions
         /// </summary>
         Mention[] GetMentions();

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/JwtTokenRefresher.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/JwtTokenRefresher.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Connector
             this.credentials = credentials;
         }
 
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default(CancellationToken))
         {
             HttpResponseMessage response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/StateAPI/Models/BotData.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/StateAPI/Models/BotData.cs
@@ -21,9 +21,8 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Initializes a new instance of the BotData class.
         /// </summary>
-        public BotData(string eTag = default(string), object data = default(object))
+        public BotData(string eTag = @"*", object data = default(object))
         {
-            ETag = eTag;
             Data = data;
         }
 

--- a/CSharp/Samples/PizzaBot/PizzaOrderDialog.cs
+++ b/CSharp/Samples/PizzaBot/PizzaOrderDialog.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Bot.Sample.PizzaBot
 
             var days = (IEnumerable<Days>)Enum.GetValues(typeof(Days));
             PromptDialog.Choice(context, StoreHoursResult, days, "Which day of the week?",
-                descriptions: from day in days
+                titles: from day in days
                               select (day == Days.Saturday || day == Days.Sunday) ? day.ToString() + "(no holidays)" : day.ToString());
         }
 

--- a/CSharp/Tests/Microsoft.Bot.Builder.Tests/BotDataTests.cs
+++ b/CSharp/Tests/Microsoft.Bot.Builder.Tests/BotDataTests.cs
@@ -37,10 +37,8 @@ using Microsoft.Bot.Builder.Dialogs.Internals;
 using Microsoft.Bot.Connector;
 using Microsoft.Rest;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading;
@@ -66,7 +64,7 @@ namespace Microsoft.Bot.Builder.Tests
                 Assert.IsTrue(bag.TryGetValue(key, out existing));
                 Assert.AreEqual(existing, value);
 
-                existing = bag.Get<T>(key);
+                existing = bag.GetValue<T>(key);
                 Assert.AreEqual(existing, value);
 
                 Assert.AreEqual(count + 1, bag.Count);

--- a/CSharp/Tests/Microsoft.Bot.Builder.Tests/ChainTests.cs
+++ b/CSharp/Tests/Microsoft.Bot.Builder.Tests/ChainTests.cs
@@ -31,6 +31,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using Autofac;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Internals;
+using Microsoft.Bot.Builder.Internals.Fibers;
+using Microsoft.Bot.Connector;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -39,15 +45,6 @@ using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Builder.Dialogs.Internals;
-using Microsoft.Bot.Builder.Internals.Fibers;
-using Microsoft.Bot.Connector;
-
-using Autofac;
-
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Bot.Builder.Tests
 {
@@ -566,7 +563,7 @@ namespace Microsoft.Bot.Builder.Tests
                 .Then(async (context, res) =>
                 {
 
-                    var selection = context.ConversationData.Get<string>("selected");
+                    var selection = context.ConversationData.GetValue<string>("selected");
                     if (await res)
                     {
                         return $"{selection} is selected!";

--- a/CSharp/Tests/Microsoft.Bot.Builder.Tests/ConversationTest.cs
+++ b/CSharp/Tests/Microsoft.Bot.Builder.Tests/ConversationTest.cs
@@ -31,14 +31,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Net.Http;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Web;
 using Autofac;
 using Microsoft.Bot.Builder.ConnectorEx;
 using Microsoft.Bot.Builder.Dialogs;
@@ -48,6 +40,14 @@ using Microsoft.Bot.Connector;
 using Microsoft.Rest;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
 
 namespace Microsoft.Bot.Builder.Tests
 {
@@ -467,7 +467,7 @@ namespace Microsoft.Bot.Builder.Tests
 
                     var botData = scope.Resolve<IBotData>();
                     await botData.LoadAsync(default(CancellationToken));
-                    Assert.IsTrue(botData.UserData.Get<bool>("resume"));
+                    Assert.IsTrue(botData.UserData.GetValue<bool>("resume"));
                 }
             }
         }


### PR DESCRIPTION
This PR contains a number of small, but impactful, changes to the API to make it more digestable. These feedback points came out of a hack with a partner.

1. In order to use `GetStateClient()` today you **must** use the full-blown `Activity` object. This is less desirable than using one of the interfaces from which `Activity` inherits (which has all the necessary information to perform the same work). So, I changed those methods to be extensions off the interface. Addresses #2387 
1. It's confusing that `IBotDataBag` has a `Set*Value*` method but only a `Get` method (one would reasonably expect `Get*Value*` here). Fixed and marked `Get` obsolete with a warning.
1. Added a method `GetValueOrDefault` on `IBotDataBag` so users can retrieve a value from a data bag or, optionally, get back either `default(T)` or a default of their choosing. Avoids much `if/else` boilerplate when retrieving values.
2. The `Forward` method on `IDialogContext` required a `cancellationToken` parameter, but other `IDialogContext` methods treat this as optional. Unified this.
3. During our discussions during the hack w/ the BF team, we found that `ETag` should be set to `"*"` when updating data sets in the state client so set this as the default value for `ETag`.
4. Checked throughout the framework for the optional status of the `cancellationToken` elsewhere. Unified it with a default value of `default(CancellationToken)`
5. `PromptDialog.Choice` used different verbiage for labeling the `CardAction` `title` and `value` parameters. I unified this terminology and also added an overload that made more sense; one that takes in an `IEnumerable<KeyValuePair<string,T>>` which is a more obvious descriptor of the purpose of the parameter.
6. Often developers end up with a `NullReferenceException` at runtime because they have done something like this:
```
var card = new HeroCard();
card.Buttons.Add(new CardAction("buttonText"));
```
This blows up because `HeroCard`'s `Buttons` property is initialized to `null`. Fixed this throughout our Card objects.

9. `CardAction` can be constructed and sent out without the `Type` property defined. This isn't valid and results in no response sent to the user (and an exception within the bot). Instead, default `Type` to something; I chose `ImBack`.
10. `Activity` can be created (eg: `new Activity()`) and will immediately blow up if a developer tries to `.Attachments.Add(new HeroCard().ToAttachment())` because the `Attachments` property is null. Instead of only initializing it to blank during `CreateReply()`, just ensure it's blank and `.Add`-able when defaultly constructed.
11. The Action type `Invoke` is not on the `ActionTypes` constants class. This is a valid Action Type, so it should be present.
12. Despite the XML doco, `IActivity.GetChannelData<T>()` does not return `default(T)` if it's not able to coerce `.ChannelData` in to type `T`. Rather, it throws an exception. Added `IActivity.TryGetValue<T>(out T instance)` to the set of extension methods available on `IActivity`.