### PR TITLE
[Node SDK] #1530 update EntityRecognizer.parseNumer() numberExp regex

### DIFF
--- a/Node/core/lib/dialogs/EntityRecognizer.js
+++ b/Node/core/lib/dialogs/EntityRecognizer.js
@@ -203,6 +203,6 @@ var EntityRecognizer = (function () {
 EntityRecognizer.dateExp = /^\d{4}-\d{2}-\d{2}/i;
 EntityRecognizer.yesExp = /^(1|y|yes|yep|sure|ok|true)(\W|$)/i;
 EntityRecognizer.noExp = /^(2|n|no|nope|not|false)(\W|$)/i;
-EntityRecognizer.numberExp = /[+-]?(?:\d+\.?\d*|\d*\.?\d+)/;
+EntityRecognizer.numberExp = /^[0-9]*$/;
 EntityRecognizer.ordinalWords = 'first|second|third|fourth|fifth|sixth|seventh|eigth|ninth|tenth';
 exports.EntityRecognizer = EntityRecognizer;


### PR DESCRIPTION
Fix for #1530 - Update EntityRecognizer.parseNumber() regex contained in numberExp to `/^[0-9]*$/`