### PR TITLE
Update PromptConfirm's Options and Patterns getter

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/Dialogs/PromptDialog.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Dialogs/PromptDialog.cs
@@ -425,6 +425,9 @@ namespace Microsoft.Bot.Builder.Dialogs
         [Serializable]
         public sealed class PromptConfirm : Prompt<bool, string>
         {
+            private static string[] options;
+            private static string[][] patterns;
+
             /// <summary>
             /// Index of yes descriptions.
             /// </summary>
@@ -442,7 +445,15 @@ namespace Microsoft.Bot.Builder.Dialogs
             {
                 get
                 {
-                    return new string[] { Resources.MatchYes.SplitList().First(), Resources.MatchNo.SplitList().First() };
+                    if (options == null)
+                    {
+                        return new string[] { Resources.MatchYes.SplitList().First(), Resources.MatchNo.SplitList().First() };
+                    }
+                    return options;
+                }
+                set
+                {
+                    options = value;
                 }
             }
 
@@ -453,7 +464,15 @@ namespace Microsoft.Bot.Builder.Dialogs
             {
                 get
                 {
-                    return new string[][] { Resources.MatchYes.SplitList(), Resources.MatchNo.SplitList() };
+                    if (patterns == null)
+                    {
+                        return new string[][] { Resources.MatchYes.SplitList(), Resources.MatchNo.SplitList() };
+                    }
+                    return patterns;
+                }
+                set
+                {
+                    patterns = value;
                 }
             }
 

--- a/CSharp/Library/Microsoft.Bot.Builder/Dialogs/PromptDialog.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Dialogs/PromptDialog.cs
@@ -434,16 +434,28 @@ namespace Microsoft.Bot.Builder.Dialogs
             /// Index of no descriptions.
             /// </summary>
             public const int No = 1;
-
+            
             /// <summary>
             /// The yes, no options for confirmation prompt
             /// </summary>
-            public static string[] Options { set; get; } = { Resources.MatchYes.SplitList().First(), Resources.MatchNo.SplitList().First() };
+            public static string[] Options
+            {
+                get
+                {
+                    return new string[] { Resources.MatchYes.SplitList().First(), Resources.MatchNo.SplitList().First() };
+                }
+            }
 
             /// <summary>
             /// The patterns for matching yes/no responses in the confirmation prompt.
             /// </summary>
-            public static string[][] Patterns { get; set; } = { Resources.MatchYes.SplitList(), Resources.MatchNo.SplitList() };
+            public static string[][] Patterns
+            {
+                get
+                {
+                    return new string[][] { Resources.MatchYes.SplitList(), Resources.MatchNo.SplitList() };
+                }
+            }
 
             /// <summary>   Constructor for a prompt confirmation dialog. </summary>
             /// <param name="prompt">   The prompt. </param>

--- a/CSharp/Tests/Microsoft.Bot.Builder.Tests/PromptTests.cs
+++ b/CSharp/Tests/Microsoft.Bot.Builder.Tests/PromptTests.cs
@@ -40,6 +40,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -72,7 +73,23 @@ namespace Microsoft.Bot.Builder.Tests
         }
     }
 
-
+    [TestClass]
+    public sealed class PromptTests
+    {
+        [TestMethod]
+        public async Task PromptConfirm_Localization()
+        {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
+            var options = PromptDialog.PromptConfirm.Options;
+            var patterns = PromptDialog.PromptConfirm.Patterns;
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("es-ES");
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("es-ES");
+            Assert.AreNotEqual(options, PromptDialog.PromptConfirm.Options);
+            Assert.AreNotEqual(patterns, PromptDialog.PromptConfirm.Patterns);
+        }
+    }
+    
     [TestClass]
     public sealed class PromptTests_Success : PromptTests_Base
     {

--- a/CSharp/Tests/Microsoft.Bot.Builder.Tests/PromptTests.cs
+++ b/CSharp/Tests/Microsoft.Bot.Builder.Tests/PromptTests.cs
@@ -74,10 +74,10 @@ namespace Microsoft.Bot.Builder.Tests
     }
 
     [TestClass]
-    public sealed class PromptTests
+    public sealed class PromptTests_Localization
     {
         [TestMethod]
-        public async Task PromptConfirm_Localization()
+        public async Task PromptLocalization_ChangeCulture()
         {
             Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
             Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
@@ -85,8 +85,30 @@ namespace Microsoft.Bot.Builder.Tests
             var patterns = PromptDialog.PromptConfirm.Patterns;
             Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("es-ES");
             Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("es-ES");
+
             Assert.AreNotEqual(options, PromptDialog.PromptConfirm.Options);
             Assert.AreNotEqual(patterns, PromptDialog.PromptConfirm.Patterns);
+        }
+
+        [TestMethod]
+        public void PromptLocalization_SetOptionsAndPatterns()
+        {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
+            var options = new string[] { "si", "no" };
+            var patterns = new string[][] {
+                new string[] { "si" , "s", "sip", "ok", "1" },
+                new string[] { "No", "n", "nop", "2" }
+            };
+
+            PromptDialog.PromptConfirm.Options = options;
+            PromptDialog.PromptConfirm.Patterns = patterns;
+
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
+
+            Assert.AreEqual(options, PromptDialog.PromptConfirm.Options);
+            Assert.AreEqual(patterns, PromptDialog.PromptConfirm.Patterns);
         }
     }
     


### PR DESCRIPTION
This address the issue #1810. Now the code will be executed every time the property is called.