### PR TITLE
[Node SDK] Fix vulnerability in module base64url@1.0.6

### DIFF
--- a/Node/core/package.json
+++ b/Node/core/package.json
@@ -20,7 +20,7 @@
   "typings": "./lib/botbuilder.d.ts",
   "dependencies": {
     "async": "^1.5.2",
-    "base64url": "^1.0.6",
+    "base64url": "^2.0.0",
     "chrono-node": "^1.1.3",
     "jsonwebtoken": "^7.0.1",
     "promise": "^7.1.1",


### PR DESCRIPTION
**Uninitialized Memory Exposure**
_Medium severity_
Vulnerable module: concat-stream
Introduced through: concat-stream@1.4.10

**Detailed paths**
Introduced through: base64url@1.0.6 › concat-stream@1.4.10

**Overview**
`concat-stream` is writable stream that concatenates strings or binary data and calls a callback with the result. Affected versions of the package are vulnerable to Uninitialized Memory Exposure.

A possible memory disclosure vulnerability exists when a value of type number is provided to the `stringConcat()` method and results in concatenation of uninitialized memory to the stream collection.

This is a result of unobstructed use of the Buffer constructor, whose [insecure default constructor increases the odds of memory leakage.](https://snyk.io/blog/exploiting-buffer/)

https://snyk.io/test/npm/base64url/1.0.6