### PR TITLE
[C# SDK] Improve logic to auto register ASPNET service provider

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder.Autofac/Dialogs/DialogModule.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Autofac/Dialogs/DialogModule.cs
@@ -410,7 +410,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
         /// <param name="builder">The builder used to register dependencies.</param>
         private void RegisterBotConnectorImplementation(ContainerBuilder builder)
         {
-            // service provider is assumed to be availble at this point
+            // service provider is assumed to be available at this point
             // For ASPNET platform, it will be auto-registered
             // For all other platforms, consumer is expected to set up provider during startup
             builder.Register<ServiceProvider>(c => ServiceProvider.Instance)

--- a/CSharp/Library/Microsoft.Bot.Builder.Autofac/Dialogs/DialogModule.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Autofac/Dialogs/DialogModule.cs
@@ -410,35 +410,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
         /// <param name="builder">The builder used to register dependencies.</param>
         private void RegisterBotConnectorImplementation(ContainerBuilder builder)
         {
-            if (ServiceProvider.IsRegistered)
-            {
-                builder.Register<ServiceProvider>(c => ServiceProvider.Instance)
-                    .AsSelf()
-                    .SingleInstance();
-            }
-            else
-            {
-                // Finds the bot connector being used in this application domain
-                // that is not the common connector assembly
-                System.Reflection.Assembly connectorAssembly = AppDomain.CurrentDomain.
-                    GetAssemblies()
-                    .Where(a => a.FullName.StartsWith("Microsoft.Bot.Connector"))
-                    .Where(a => a != typeof(BotData).Assembly)
-                    .FirstOrDefault();
-
-                if (connectorAssembly != null)
-                {
-                    // register the IServiceProvider instance provided in the connector with the Common connector
-                    builder.RegisterAssemblyTypes(connectorAssembly)
-                        .Where(t => t.IsAssignableTo<IServiceProvider>())
-                        .AsImplementedInterfaces()
-                        .SingleInstance();
-
-                    builder.Register<ServiceProvider>(c => { if (!ServiceProvider.IsRegistered) { ServiceProvider.RegisterServiceProvider(c.Resolve<IServiceProvider>()); } return ServiceProvider.Instance; })
-                        .AsSelf()
-                        .SingleInstance();
-                }
-            }
+            // service provider is assumed to be availble at this point
+            // For ASPNET platform, it will be auto-registered
+            // For all other platforms, consumer is expected to set up provider during startup
+            builder.Register<ServiceProvider>(c => ServiceProvider.Instance)
+                .AsSelf()
+                .SingleInstance();
         }
     }
 

--- a/CSharp/Library/Microsoft.Bot.Connector.NetFramework/BotAuthentication.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.NetFramework/BotAuthentication.cs
@@ -17,13 +17,6 @@ namespace Microsoft.Bot.Connector
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
     public class BotAuthentication : ActionFilterAttribute
     {
-        static BotAuthentication()
-        {
-            // This is a hack to trigger service provider auto-registration with the common bot connector assembly
-            // This is only to support a non-breaking change for consumers of ASPNET BotConnector that do not use BotBuilder
-            BotServiceProvider.Instance.GetHashCode();
-        }
-
         /// <summary>
         /// Microsoft AppId for the bot 
         /// </summary>

--- a/CSharp/Library/Microsoft.Bot.Connector.NetFramework/BotServiceProvider.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.NetFramework/BotServiceProvider.cs
@@ -32,12 +32,6 @@ namespace Microsoft.Bot.Connector
                 .AddTraceSource("Microsoft.Bot.Connector"));
 
             Services = new ReadOnlyDictionary<Type, object>(services);
-
-            // Auto register with base implementation
-            if (!ServiceProvider.IsRegistered)
-            {
-                ServiceProvider.RegisterServiceProvider(new BotServiceProvider());
-            }
         }
 
         public static ServiceProvider Instance { get { return ServiceProvider.Instance; } }

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ServiceProvider.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ServiceProvider.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Bot.Connector
         {
             if (ServiceProvider.instance == null)
             {
-                throw new InvalidOperationException("The service provider instance was not register. Please call RegisterServiceProvider before using ServiceProvider.Instance.");
+                throw new InvalidOperationException("The service provider instance was not registered. Please call RegisterServiceProvider before using ServiceProvider.Instance.");
             }
         }
 

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ServiceProvider.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ServiceProvider.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Reflection;
 using System.Linq;
+using System.Diagnostics;
 
 namespace Microsoft.Bot.Connector
 {
@@ -123,10 +124,11 @@ namespace Microsoft.Bot.Connector
                 var connectorAssemblyName = new AssemblyName(AspNetBotConnectorAssemblyName);
                 connectorAssembly = Assembly.Load(connectorAssemblyName);
             }
-            catch (Exception)
+            catch (Exception exception)
             {
                 // assembly not available
                 // cannot log, because we don't have service provider to get logger from
+                Debug.WriteLine($"Couldn't load {AspNetBotConnectorAssemblyName}. This is not a problem, unless you are using ASP.NET. Error details: ${exception}");
             }
 
             if (connectorAssembly != null)

--- a/CSharp/Samples/SimpleEchoBot/App_Start/WebApiConfig.cs
+++ b/CSharp/Samples/SimpleEchoBot/App_Start/WebApiConfig.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
+using SimpleEchoBot.Controllers;
 
 namespace SimpleEchoBot
 {
@@ -31,6 +32,12 @@ namespace SimpleEchoBot
                 name: "DefaultApi",
                 routeTemplate: "api/{controller}/{id}",
                 defaults: new { id = RouteParameter.Optional }
+            );
+
+            config.Routes.MapHttpRoute(
+                name: "ConnectorOnlytApi",
+                routeTemplate: "connectorOnly/messages/{id}",
+                defaults: new { id = RouteParameter.Optional, controller = "connectorOnly" }
             );
         }
     }

--- a/CSharp/Samples/SimpleEchoBot/App_Start/WebApiConfig.cs
+++ b/CSharp/Samples/SimpleEchoBot/App_Start/WebApiConfig.cs
@@ -35,7 +35,7 @@ namespace SimpleEchoBot
             );
 
             config.Routes.MapHttpRoute(
-                name: "ConnectorOnlytApi",
+                name: "ConnectorOnlyApi",
                 routeTemplate: "connectorOnly/messages/{id}",
                 defaults: new { id = RouteParameter.Optional, controller = "connectorOnly" }
             );

--- a/CSharp/Samples/SimpleEchoBot/Controllers/ConnectorOnlyController.cs
+++ b/CSharp/Samples/SimpleEchoBot/Controllers/ConnectorOnlyController.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Description;
+using Microsoft.Bot.Connector;
+
+namespace SimpleEchoBot.Controllers
+{
+    /// <summary>
+    /// A controller that shows how to use only the Bot Connector to handle messages.
+    /// </summary>
+    public class ConnectorOnlyController : ApiController
+    {
+        /// <summary>
+        /// POST: api/Messages
+        /// receive a message from a user and send replies
+        /// </summary>
+        /// <param name="activity"></param>
+        [ResponseType(typeof(void))]
+        public virtual async Task<HttpResponseMessage> Post([FromBody] Activity activity)
+        {
+            // check if activity is of type message
+            if (activity != null && activity.GetActivityType() == ActivityTypes.Message)
+            {
+                var connector = new ConnectorClient(new Uri(activity.ServiceUrl));
+                Activity reply = activity.CreateReply($"You sent {activity.Text} which was {activity.Text.Length} characters");
+                await connector.Conversations.ReplyToActivityAsync(reply);
+            }
+            else
+            {
+                HandleSystemMessage(activity);
+            }
+            return new HttpResponseMessage(System.Net.HttpStatusCode.Accepted);
+        }
+
+        private Activity HandleSystemMessage(Activity message)
+        {
+            if (message.Type == ActivityTypes.DeleteUserData)
+            {
+                // Implement user deletion here
+                // If we handle user deletion, return a real message
+            }
+            else if (message.Type == ActivityTypes.ConversationUpdate)
+            {
+                // Handle conversation state changes, like members being added and removed
+                // Use Activity.MembersAdded and Activity.MembersRemoved and Activity.Action for info
+                // Not available in all channels
+            }
+            else if (message.Type == ActivityTypes.ContactRelationUpdate)
+            {
+                // Handle add/remove from contact lists
+                // Activity.From + Activity.Action represent what happened
+            }
+            else if (message.Type == ActivityTypes.Typing)
+            {
+                // Handle knowing tha the user is typing
+            }
+            else if (message.Type == ActivityTypes.Ping)
+            {
+            }
+
+            return null;
+        }
+    }
+}

--- a/CSharp/Samples/SimpleEchoBot/Microsoft.Bot.Sample.SimpleEchoBot.csproj
+++ b/CSharp/Samples/SimpleEchoBot/Microsoft.Bot.Sample.SimpleEchoBot.csproj
@@ -195,6 +195,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Start\WebApiConfig.cs" />
+    <Compile Include="Controllers\ConnectorOnlyController.cs" />
     <Compile Include="Controllers\MessagesController.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>


### PR DESCRIPTION
Description of problem
----------
#2590 

Usage of ASPNET BotConnector without built-in authentication or BotBuilder would require manually registering *Microsoft.Bot.Connector.BotServiceProvider* with the common library, which breaks backward compatibility.

Proposed solution
----------
Currently auto-registration of ASPNET connector happens in two places [DialogModule.cs](https://github.com/Microsoft/BotBuilder/blob/develop/CSharp/Library/Microsoft.Bot.Builder.Autofac/Dialogs/DialogModule.cs#L423) and from static constructor in [BotServiceProvider](https://github.com/Microsoft/BotBuilder/blob/develop/CSharp/Library/Microsoft.Bot.Connector.NetFramework/BotServiceProvider.cs#L39), the latter being leveraged by BotAuthentication. This implies that only usages with authentication and/or BotBuilder would be backward compatible (i.e. not require manual registration of the ASPNET connector service provider).

To circumvent that limitation, the auto-registration was moved to the common portable library and it is done through reflection.

With this change, AspNet Core service provider is still required to be registered on Startup, as before.

Testing
----------

- [x] Unit tests passing (exception of PromptSuccess_Confirm_Yes and PromptSuccess_Confirm_Yes_CaseInsensitive that fail with or without these changes)
- [x] AspNet with bot builder with authentication
- [x] AspNet with bot builder without authentication
- [x] AspNet without bot builder with authentication
- [x] AspNet without bot builder without authentication
- [x] AspNetCore samples