### PR TITLE
Fix index when dealing with reverse ordinals

### DIFF
--- a/Node/core/lib/dialogs/PromptChoice.js
+++ b/Node/core/lib/dialogs/PromptChoice.js
@@ -58,7 +58,7 @@ var PromptChoice = (function (_super) {
                     if (_this.features.recognizeOrdinals) {
                         var match = PromptRecognizers_1.PromptRecognizers.findTopEntity(PromptRecognizers_1.PromptRecognizers.recognizeOrdinals(context));
                         if (match && match.score > topScore) {
-                            var index = match.entity > 0 ? match.entity - 1 : choices.length - match.entity;
+                            var index = match.entity > 0 ? match.entity - 1 : choices.length + match.entity;
                             if (index >= 0 && index < choices.length) {
                                 topScore = match.score;
                                 topMatch = {

--- a/Node/core/src/dialogs/PromptChoice.ts
+++ b/Node/core/src/dialogs/PromptChoice.ts
@@ -127,7 +127,7 @@ export class PromptChoice extends Prompt<IPromptChoiceFeatures> {
                     if (this.features.recognizeOrdinals) {
                         let match = PromptRecognizers.findTopEntity(PromptRecognizers.recognizeOrdinals(context));
                         if (match && match.score > topScore) {
-                            let index = match.entity > 0 ? match.entity - 1 : choices.length - match.entity;
+                            let index = match.entity > 0 ? match.entity - 1 : choices.length + match.entity;
                             if (index >= 0 && index < choices.length) {
                                 topScore = match.score;
                                 topMatch = {


### PR DESCRIPTION
When dealing with reverse ordinals, the `match.entity` will be a negative value and so it needs to be subtracted from the `choices.length` to get the proper index. The current code is adding the `match.entity` value because its doing minus negative number.