### PR TITLE
[Docs > C#] Bringing Dialog documentation in sync with code

### DIFF
--- a/CSharp/Documentation/Dialogs.cs
+++ b/CSharp/Documentation/Dialogs.cs
@@ -79,7 +79,7 @@
     /// \until }
     /// \until }
     /// 
-    /// The first change you will notice is the addition of `private int count = 1;`. This is the state we are persisting
+    /// The first change you will notice is the addition of `protected int count = 1;`. This is the state we are persisting
     /// with this dialog on each message.  
     /// 
     /// In MessageReceivedAsync we have added check to see if the input was "reset" and if that is true we use the built-in


### PR DESCRIPTION
Noticed that there was a discrepancy between the included code and the sentence below it.