### PR TITLE
No null collections

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ActivityEx.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ActivityEx.cs
@@ -51,8 +51,6 @@ namespace Microsoft.Bot.Connector
             reply.Conversation = new ConversationAccount(isGroup: this.Conversation.IsGroup, id: this.Conversation.Id, name: this.Conversation.Name);
             reply.Text = text ?? String.Empty;
             reply.Locale = locale ?? this.Locale;
-            reply.Attachments = new List<Attachment>();
-            reply.Entities = new List<Entity>();
             return reply;
         }
 

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/Activity.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/Activity.cs
@@ -20,12 +20,18 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Initializes a new instance of the Activity class.
         /// </summary>
-        public Activity() { }
+        public Activity()
+        {
+            Attachments = new List<Attachment>();
+            Entities = new List<Entity>();
+            MembersAdded = new List<ChannelAccount>();
+            MembersRemoved = new List<ChannelAccount>();
+        }
 
         /// <summary>
         /// Initializes a new instance of the Activity class.
         /// </summary>
-        public Activity(string type = default(string), string id = default(string), DateTime? timestamp = default(DateTime?), DateTime? localTimestamp = default(DateTime?), string serviceUrl = default(string), string channelId = default(string), ChannelAccount from = default(ChannelAccount), ConversationAccount conversation = default(ConversationAccount), ChannelAccount recipient = default(ChannelAccount), string textFormat = default(string), string attachmentLayout = default(string), IList<ChannelAccount> membersAdded = default(IList<ChannelAccount>), IList<ChannelAccount> membersRemoved = default(IList<ChannelAccount>), string topicName = default(string), bool? historyDisclosed = default(bool?), string locale = default(string), string text = default(string), string speak = default(string), string inputHint = default(string), string summary = default(string), SuggestedActions suggestedActions = default(SuggestedActions), IList<Attachment> attachments = default(IList<Attachment>), IList<Entity> entities = default(IList<Entity>), object channelData = default(object), string action = default(string), string replyToId = default(string), object value = default(object), string name = default(string), ConversationReference relatesTo = default(ConversationReference), string code = default(string))
+        public Activity(string type = default(string), string id = default(string), DateTime? timestamp = default(DateTime?), DateTime? localTimestamp = default(DateTime?), string serviceUrl = default(string), string channelId = default(string), ChannelAccount from = default(ChannelAccount), ConversationAccount conversation = default(ConversationAccount), ChannelAccount recipient = default(ChannelAccount), string textFormat = default(string), string attachmentLayout = default(string), IList<ChannelAccount> membersAdded = default(IList<ChannelAccount>), IList<ChannelAccount> membersRemoved = default(IList<ChannelAccount>), string topicName = default(string), bool? historyDisclosed = default(bool?), string locale = default(string), string text = default(string), string speak = default(string), string inputHint = default(string), string summary = default(string), SuggestedActions suggestedActions = default(SuggestedActions), IList<Attachment> attachments = default(IList<Attachment>), IList<Entity> entities = default(IList<Entity>), object channelData = default(object), string action = default(string), string replyToId = default(string), object value = default(object), string name = default(string), ConversationReference relatesTo = default(ConversationReference), string code = default(string)) : this()
         {
             Type = type;
             Id = id;
@@ -38,8 +44,6 @@ namespace Microsoft.Bot.Connector
             Recipient = recipient;
             TextFormat = textFormat;
             AttachmentLayout = attachmentLayout;
-            MembersAdded = membersAdded;
-            MembersRemoved = membersRemoved;
             TopicName = topicName;
             HistoryDisclosed = historyDisclosed;
             Locale = locale;
@@ -48,8 +52,6 @@ namespace Microsoft.Bot.Connector
             InputHint = inputHint;
             Summary = summary;
             SuggestedActions = suggestedActions;
-            Attachments = attachments;
-            Entities = entities;
             ChannelData = channelData;
             Action = action;
             ReplyToId = replyToId;
@@ -57,6 +59,10 @@ namespace Microsoft.Bot.Connector
             Name = name;
             RelatesTo = relatesTo;
             Code = code;
+            MembersAdded = membersAdded ?? new List<ChannelAccount>();
+            MembersRemoved = membersRemoved ?? new List<ChannelAccount>();
+            Attachments = attachments ?? new List<Attachment>();
+            Entities = entities ?? new List<Entity>();
         }
 
         /// <summary>

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/AnimationCard.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/AnimationCard.cs
@@ -65,13 +65,13 @@ namespace Microsoft.Bot.Connector
         /// Array of media Url objects
         /// </summary>
         [JsonProperty(PropertyName = "media")]
-        public IList<MediaUrl> Media { get; set; }
+        public IList<MediaUrl> Media { get; set; } = new List<MediaUrl>();
 
         /// <summary>
         /// Set of actions applicable to the current card
         /// </summary>
         [JsonProperty(PropertyName = "buttons")]
-        public IList<CardAction> Buttons { get; set; }
+        public IList<CardAction> Buttons { get; set; } = new List<CardAction>();
 
         /// <summary>
         /// Is it OK for this content to be shareable with others

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/AudioCard.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/AudioCard.cs
@@ -73,13 +73,13 @@ namespace Microsoft.Bot.Connector
         /// Array of media Url objects
         /// </summary>
         [JsonProperty(PropertyName = "media")]
-        public IList<MediaUrl> Media { get; set; }
+        public IList<MediaUrl> Media { get; set; } = new List<MediaUrl>();
 
         /// <summary>
         /// Set of actions applicable to the current card
         /// </summary>
         [JsonProperty(PropertyName = "buttons")]
-        public IList<CardAction> Buttons { get; set; }
+        public IList<CardAction> Buttons { get; set; } = new List<CardAction>();
 
         /// <summary>
         /// Is it OK for this content to be shareable with others

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/HeroCard.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/HeroCard.cs
@@ -56,19 +56,18 @@ namespace Microsoft.Bot.Connector
         /// Array of images for the card
         /// </summary>
         [JsonProperty(PropertyName = "images")]
-        public IList<CardImage> Images { get; set; }
+        public IList<CardImage> Images { get; set; } = new List<CardImage>();
 
         /// <summary>
         /// Set of actions applicable to the current card
         /// </summary>
         [JsonProperty(PropertyName = "buttons")]
-        public IList<CardAction> Buttons { get; set; }
+        public IList<CardAction> Buttons { get; set; } = new List<CardAction>();
 
         /// <summary>
         /// This action will be activated when user taps on the card itself
         /// </summary>
         [JsonProperty(PropertyName = "tap")]
         public CardAction Tap { get; set; }
-
     }
 }

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/ReceiptCard.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/ReceiptCard.cs
@@ -46,13 +46,13 @@ namespace Microsoft.Bot.Connector
         /// Array of Receipt Items
         /// </summary>
         [JsonProperty(PropertyName = "items")]
-        public IList<ReceiptItem> Items { get; set; }
+        public IList<ReceiptItem> Items { get; set; } = new List<ReceiptItem>();
 
         /// <summary>
         /// Array of Fact Objects   Array of key-value pairs.
         /// </summary>
         [JsonProperty(PropertyName = "facts")]
-        public IList<Fact> Facts { get; set; }
+        public IList<Fact> Facts { get; set; } = new List<Fact>();
 
         /// <summary>
         /// This action will be activated when user taps on the card
@@ -82,7 +82,7 @@ namespace Microsoft.Bot.Connector
         /// Set of actions applicable to the current card
         /// </summary>
         [JsonProperty(PropertyName = "buttons")]
-        public IList<CardAction> Buttons { get; set; }
+        public IList<CardAction> Buttons { get; set; } = new List<CardAction>();
 
     }
 }

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/SigninCard.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/SigninCard.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Bot.Connector
         /// Action to use to perform signin
         /// </summary>
         [JsonProperty(PropertyName = "buttons")]
-        public IList<CardAction> Buttons { get; set; }
+        public IList<CardAction> Buttons { get; set; } = new List<CardAction>();
 
     }
 }

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/ThumbnailCard.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/ThumbnailCard.cs
@@ -56,13 +56,13 @@ namespace Microsoft.Bot.Connector
         /// Array of images for the card
         /// </summary>
         [JsonProperty(PropertyName = "images")]
-        public IList<CardImage> Images { get; set; }
+        public IList<CardImage> Images { get; set; } = new List<CardImage>();
 
         /// <summary>
         /// Set of actions applicable to the current card
         /// </summary>
         [JsonProperty(PropertyName = "buttons")]
-        public IList<CardAction> Buttons { get; set; }
+        public IList<CardAction> Buttons { get; set; } = new List<CardAction>();
 
         /// <summary>
         /// This action will be activated when user taps on the card itself

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/VideoCard.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/Models/VideoCard.cs
@@ -72,13 +72,13 @@ namespace Microsoft.Bot.Connector
         /// Array of media Url objects
         /// </summary>
         [JsonProperty(PropertyName = "media")]
-        public IList<MediaUrl> Media { get; set; }
+        public IList<MediaUrl> Media { get; set; } = new List<MediaUrl>();
 
         /// <summary>
         /// Set of actions applicable to the current card
         /// </summary>
         [JsonProperty(PropertyName = "buttons")]
-        public IList<CardAction> Buttons { get; set; }
+        public IList<CardAction> Buttons { get; set; } = new List<CardAction>();
 
         /// <summary>
         /// Is it OK for this content to be shareable with others


### PR DESCRIPTION
Collections off our activity and card objects should be able to have `.Add()` run on them readily; today they default to `null` values which causes a first-time-crash almost without fail for developers getting to learn our API.