### PR TITLE
[C# SDK] ETag should default to *, not empty

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/StateAPI/Models/BotData.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/StateAPI/Models/BotData.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Initializes a new instance of the BotData class.
         /// </summary>
-        public BotData(string eTag = default(string), object data = default(object))
+        public BotData(string eTag = @"*", object data = default(object))
         {
             ETag = eTag;
             Data = data;


### PR DESCRIPTION
@matvelloso and I were told this should be what devs do when playing with the UserData via the State Client in a discussion regarding this behavior during a hackfest a number of weeks ago. "always set etag to '*'." This is also what is documented [here](https://docs.botframework.com/en-us/csharp/builder/sdkreference/stateapi.html):
![image](https://cloud.githubusercontent.com/assets/20270743/25541603/1700fd72-2c04-11e7-9f72-5bd15119bb88.png)

