### PR TITLE
Fix PromptChoice case insensitive issue when matching options

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/Dialogs/PromptRecognizer.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Dialogs/PromptRecognizer.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             var index = 0;
             foreach (var value in values)
             {
-                var text = value.ToString();
+                var text = value?.ToString().Trim().ToLowerInvariant();
                 var topScore = 0.0;
                 IList<string> vTokens = new List<string>();
                 foreach (Match match in simpleTokenizer.Matches(text))

--- a/CSharp/Tests/Microsoft.Bot.Builder.Tests/PromptTests.cs
+++ b/CSharp/Tests/Microsoft.Bot.Builder.Tests/PromptTests.cs
@@ -245,6 +245,20 @@ namespace Microsoft.Bot.Builder.Tests
         }
         
         [TestMethod]
+        public async Task PromptSuccess_Choice_MessageCaseInsensitive()
+        {
+            var choices = new[] { "one", "two", "three" };
+            await PromptSuccessAsync((context, resume) => PromptDialog.Choice(context, resume, choices, PromptText, promptStyle: PromptStyle.None), "Two", "two");
+        }
+
+        [TestMethod]
+        public async Task PromptSuccess_Choice_OptionsCaseInsensitive()
+        {
+            var choices = new[] { "One", "Two", "Three" };
+            await PromptSuccessAsync((context, resume) => PromptDialog.Choice(context, resume, choices, PromptText, promptStyle: PromptStyle.None), "two", "Two");
+        }
+
+        [TestMethod]
         public async Task PromptSuccess_Choice_Ordinal()
         {
             var choices = new[] { "one", "two", "three" };


### PR DESCRIPTION
Options matching was failing in a PromptChoice like the following:

```
 var severities = new string[] { "High", "Normal", "Low" };
PromptDialog.Choice(context, this.SeverityMessageReceivedAsync, severities, "Choose the severity");
```

due to missing case insensitive match. The user message is being converted to lower case, however, the option was maintaining the original case. This PR fix this by converting the option to lower case too.