### PR TITLE
[Node SDK] Add localization to EntityRecognizer.parseBoolean()

### DIFF
--- a/Node/core/lib/dialogs/EntityRecognizer.js
+++ b/Node/core/lib/dialogs/EntityRecognizer.js
@@ -1,6 +1,7 @@
 "use strict";
 var utils = require("../utils");
 var chrono = require("chrono-node");
+var consts = require("../consts");
 var EntityRecognizer = (function () {
     function EntityRecognizer() {
     }
@@ -127,8 +128,19 @@ var EntityRecognizer = (function () {
         }
         return Number.NaN;
     };
-    EntityRecognizer.parseBoolean = function (utterance) {
+    EntityRecognizer.parseBoolean = function (utterance, context) {
         utterance = utterance.trim();
+        if (context) {
+            var locale = context.preferredLocale();
+            var pattern = context.localizer.trygettext(locale, 'yesExp', consts.Library.system);
+            if (pattern) {
+                EntityRecognizer.yesExp = new RegExp(pattern, 'i');
+            }
+            pattern = context.localizer.trygettext(locale, 'noExp', consts.Library.system);
+            if (pattern) {
+                EntityRecognizer.noExp = new RegExp(pattern, 'i');
+            }
+        }
         if (EntityRecognizer.yesExp.test(utterance)) {
             return true;
         }

--- a/Node/core/lib/locale/de/BotBuilder.json
+++ b/Node/core/lib/locale/de/BotBuilder.json
@@ -9,5 +9,7 @@
     "default_choice": "Das habe ich nicht verstanden. Bitte waehlen Sie aus der Liste.",
     "default_time": "Die eingegebene Zeit habe ich nicht verstanden. Bitte geben Sie es im folgenden Format ein (MM/TT/JJJJ HH:MM:SS).",
     "default_file": "Ich habe nichts empfangen. Bitte versuchen Sie es erneut.",
-    "default_error": "Ups. Irgendetwas ist schief gelaufen. Wir versuchen es erneut."
+    "default_error": "Ups. Irgendetwas ist schief gelaufen. Wir versuchen es erneut.",
+    "yesExp": "^(1|ja)(\\W|$)",
+    "noExp": "^(2|nein)(\\W|$)"
 }

--- a/Node/core/lib/locale/en/BotBuilder.json
+++ b/Node/core/lib/locale/en/BotBuilder.json
@@ -18,5 +18,7 @@
     "number_minValue_error": "The number you entered was below the minimum allowed value of %(minValue)d. Please enter a valid number.",
     "number_maxValue_error": "The number you entered was above the maximum allowed value of %(maxValue)d. Please enter a valid number.",
     "number_range_error": "The number you entered was outside the allowed range of %(minValue)d to %(maxValue)d. Please enter a valid number.",
-    "number_integer_error": "The number you entered was not an integer. Please enter a number without a decimal mark."
+    "number_integer_error": "The number you entered was not an integer. Please enter a number without a decimal mark.",
+    "yesExp": "^(1|y|yes|yep|sure|ok|true)(\\W|$)",
+    "noExp": "^(2|n|no|nope|not|false)(\\W|$)"
 }

--- a/Node/core/lib/locale/es/BotBuilder.json
+++ b/Node/core/lib/locale/es/BotBuilder.json
@@ -9,5 +9,7 @@
     "default_choice": "No se pudo reconocer su respuesta. Por favor seleccione una opción de la lista.",
     "default_time": "No se pudo reconocer el formato de la fecha. Por favor vuelva a intentar (MM/DD/YYYY HH:MM:SS).",
     "default_file": "No se pudo recibir el archivo. Por favor vuelva a intentar.",
-    "default_error": "Oops. Ocurrió un problema. Por favor vuelva a intentar."
+    "default_error": "Oops. Ocurrió un problema. Por favor vuelva a intentar.",
+    "yesExp": "^(1|s|si|vale|ok)(\\W|$)",
+    "noExp": "^(2|n|no|falso)(\\W|$)"
 }   

--- a/Node/core/lib/locale/fr/BotBuilder.json
+++ b/Node/core/lib/locale/fr/BotBuilder.json
@@ -10,5 +10,7 @@
     "default_time": "Je n'ai pas reconnu la date. Veuillez réessayer en utilisant le format (MM/JJ/AAAA HH:MM:SS).",
     "default_file": "Je n'ai reçu aucun fichier. Veuillez réessayer.",
     "default_error": "Oups. Il y a eu un problème et je crains que nous devions recommencer.",
-    "active_dialog_label": "Entrée active"
+    "active_dialog_label": "Entrée active",
+    "yesExp": "^(1|oui)(\\W|$)",
+    "noExp": "^(2|non)(\\W|$)"
 }   

--- a/Node/core/lib/locale/it/BotBuilder.json
+++ b/Node/core/lib/locale/it/BotBuilder.json
@@ -9,5 +9,7 @@
     "default_choice": "Non ho capito. Per favore scegli un'opzione dalla lista.",
     "default_time": "Il valore inserito non sembra essere una data. Attualmente capisco solo date in inglese. Per favore riprova specificando la data in inglese (p.es. 17 August 2013, 08/17/2013 [nota: il mese viene prima in questo formato!], 5 days ago, Today, ecc.).",
     "default_file": "Non ho ricevuto nessun file. Riprova per favore.",
-    "default_error": "Ops. Qualcosa è andato storto e dobbiamo ricominciare da capo."
+    "default_error": "Ops. Qualcosa è andato storto e dobbiamo ricominciare da capo.",
+    "yesExp": "^(1|sì)(\\W|$)",
+    "noExp": "^(2|no)(\\W|$)"
 }   

--- a/Node/core/lib/locale/pt/BotBuilder.json
+++ b/Node/core/lib/locale/pt/BotBuilder.json
@@ -9,5 +9,7 @@
     "default_choice": "Não consigo entender. Por favor, selecione uma opção da lista.",
     "default_time": "Não consigo entender o formato que você usou. Por favor, tente novamente usando o formato (MM/DD/AAAA HH:MM:SS).",
     "default_file": "Não consegui receber o arquivo. Por favor, tente novamente.",
-    "default_error": "Oops. Algo deu errado. Por favor, comece novamente."
+    "default_error": "Oops. Algo deu errado. Por favor, comece novamente.",
+    "yesExp": "^(1|sim)(\\W|$)",
+    "noExp": "^(2|não)(\\W|$)"
 }

--- a/Node/core/lib/locale/zh-Hans/BotBuilder.json
+++ b/Node/core/lib/locale/zh-Hans/BotBuilder.json
@@ -5,9 +5,13 @@
     "list_or": "或",
     "list_or_more": ", 或",
     "confirm_yes": "是",
-    "confirm_no": "否",
+    "confirm_no": "不",
     "default_choice": "我没听明白。请从可选项中选择。",
     "default_time": "这好像不是日期，时间。 请输入日期，时间 (月月/日日/年年年年 时时:分分:秒秒)。",
     "default_file": "我没有收到文件，请再传一次。",
-    "default_error": "啊呀。发生故障了，我需要重启。"
+    "default_error": "啊呀。发生故障了，我需要重启。",
+    "yesExp": "^(\\u662f|\\u786e\\u8ba4|\\u662f\\u7684|\\u597d\\u7684|\\u597d|\\u6ca1\\u95ee\\u9898|\\u5bf9|\\u5bf9\\u7684)(\\W|$)",
+    "noExp": "^(\\u4e0d|\\u4e0d\\u662f|\\u4e0d\\u5bf9|\\u4e0d\\u77e5\\u9053|\\u4e0d\\u884c)(\\W|$)"
 }   
+
+

--- a/Node/core/src/dialogs/EntityRecognizer.ts
+++ b/Node/core/src/dialogs/EntityRecognizer.ts
@@ -30,10 +30,11 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+import { IRecognizeContext } from './IntentRecognizerSet';
 import * as utils from '../utils';
 import * as sprintf from 'sprintf-js';
 import * as chrono from 'chrono-node';
+import * as consts from '../consts';
 
 interface ILuisDateTimeEntity extends IEntity<string> {
     resolution: {
@@ -195,8 +196,19 @@ export class EntityRecognizer {
         return Number.NaN;
     }
 
-    static parseBoolean(utterance: string): boolean {
+    static parseBoolean(utterance: string, context?: IRecognizeContext): boolean {
         utterance = utterance.trim();
+        if (context) {
+            var locale = context.preferredLocale();
+            var pattern = context.localizer.trygettext(locale, 'yesExp', consts.Library.system);
+            if (pattern) { 
+                EntityRecognizer.yesExp = new RegExp(pattern,'i');
+            } 
+            pattern = context.localizer.trygettext(locale, 'noExp', consts.Library.system);
+            if (pattern) {
+                EntityRecognizer.noExp = new RegExp(pattern, 'i');
+            }
+        }
         if (EntityRecognizer.yesExp.test(utterance)) {
             return true;
         } else if (EntityRecognizer.noExp.test(utterance)) {

--- a/Node/core/src/dialogs/EntityRecognizer.ts
+++ b/Node/core/src/dialogs/EntityRecognizer.ts
@@ -30,7 +30,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-import { IRecognizeContext } from './IntentRecognizerSet';
+import { IRecognizeContext } from './IntentRecognizer';
 import * as utils from '../utils';
 import * as sprintf from 'sprintf-js';
 import * as chrono from 'chrono-node';


### PR DESCRIPTION
Method now checks `locale/<language>/BotBuilder.json` for `"yesExp"` and `"noExp"` before parsing utterance. 

Referencing issue #1813 