### PR TITLE
[C# SDK] PostAsync(string) should set the InputHint to ExpectingInput 

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/Dialogs/IDialogContext.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Dialogs/IDialogContext.cs
@@ -31,11 +31,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using Microsoft.Bot.Builder.Dialogs.Internals;
+using Microsoft.Bot.Connector;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder.Dialogs.Internals;
-using Microsoft.Bot.Connector;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
@@ -141,6 +141,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         {
             var message = botToUser.MakeMessage();
             message.Text = text;
+            message.InputHint = InputHints.ExpectingInput;
 
             if (!string.IsNullOrEmpty(locale))
             {


### PR DESCRIPTION
I've yet to see a situation where a bot was using PostAsync(string) and didn't expect the conversation to continue from the user in some fashion.
When this isn't the case, we'd expect the bot to be sending multiple messages, ending a conversation, etc where the developer is more likely to be using `context.MakeMessage()` to send full message objects.