### PR TITLE
[Node SDK] add 2 new EntityRecognizer methods for new LUIS List Entities

### DIFF
--- a/Node/core/lib/dialogs/EntityRecognizer.js
+++ b/Node/core/lib/dialogs/EntityRecognizer.js
@@ -13,11 +13,36 @@ var EntityRecognizer = (function () {
         }
         return null;
     };
+    EntityRecognizer.findListEntity = function (entities, value) {
+        for (var i = 0; entities && i < entities.length; i++) {
+            if (entities[i].resolution) {
+                for (var j = 0; j < entities[i].resolution.values.length; j++) {
+                    if (entities[i].resolution.values[j] == value) {
+                        return entities[i];
+                    }
+                }
+            }
+        }
+        return null;
+    };
     EntityRecognizer.findAllEntities = function (entities, type) {
         var found = [];
         for (var i = 0; entities && i < entities.length; i++) {
             if (entities[i].type == type) {
                 found.push(entities[i]);
+            }
+        }
+        return found;
+    };
+    EntityRecognizer.findAllListEntities = function (entities, value) {
+        var found = [];
+        for (var i = 0; entities && i < entities.length; i++) {
+            if (entities[i].resolution) {
+                for (var j = 0; j < entities[i].resolution.values.length; j++) {
+                    if (entities[i].resolution.values[j] == value) {
+                        found.push(entities[i]);
+                    }
+                }
             }
         }
         return found;

--- a/Node/core/lib/dialogs/EntityRecognizer.js
+++ b/Node/core/lib/dialogs/EntityRecognizer.js
@@ -15,7 +15,7 @@ var EntityRecognizer = (function () {
     };
     EntityRecognizer.findListEntity = function (entities, value) {
         for (var i = 0; entities && i < entities.length; i++) {
-            if (entities[i].resolution) {
+            if (entities[i].resolution && entities[i].resolution.values) {
                 for (var j = 0; j < entities[i].resolution.values.length; j++) {
                     if (entities[i].resolution.values[j] == value) {
                         return entities[i];
@@ -37,7 +37,7 @@ var EntityRecognizer = (function () {
     EntityRecognizer.findAllListEntities = function (entities, value) {
         var found = [];
         for (var i = 0; entities && i < entities.length; i++) {
-            if (entities[i].resolution) {
+            if (entities[i].resolution && entities[i].resolution.values) {
                 for (var j = 0; j < entities[i].resolution.values.length; j++) {
                     if (entities[i].resolution.values[j] == value) {
                         found.push(entities[i]);

--- a/Node/core/src/dialogs/EntityRecognizer.ts
+++ b/Node/core/src/dialogs/EntityRecognizer.ts
@@ -30,7 +30,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-import { IRecognizeContext } from './IntentRecognizerSet';
+import { IRecognizeContext } from './IntentRecognizer';
 import * as utils from '../utils';
 import * as sprintf from 'sprintf-js';
 import * as chrono from 'chrono-node';
@@ -77,11 +77,38 @@ export class EntityRecognizer {
         return null;
     }
 
+   static findListEntity(entities: IEntity<string>[], value: string): IEntity<string> {
+        for (var i = 0; entities && i < entities.length; i++) {
+            if (entities[i].resolution) {
+                for (var j = 0; j < entities[i].resolution.values.length; j++) {
+                    if (entities[i].resolution.values[j] == value) {
+                        return entities[i];
+                    }
+                }
+            } 
+        }
+        return null;
+    }
+
     static findAllEntities(entities: IEntity<string>[], type: string): IEntity<string>[] {
         var found: IEntity<string>[] = [];
         for (var i = 0; entities && i < entities.length; i++) {
             if (entities[i].type == type) {
                 found.push(entities[i]);
+            }
+        }
+        return found;
+    }
+
+    static findAllListEntities(entities: IEntity<string>[], value: string): IEntity<string>[] {
+        var found: IEntity<string>[] = [];
+        for (var i = 0; entities && i < entities.length; i++) {
+            if (entities[i].resolution) {
+                for (var j = 0; j < entities[i].resolution.values.length; j++) {
+                    if (entities[i].resolution.values[j] == value) {
+                        found.push(entities[i]);
+                    }
+                }
             }
         }
         return found;

--- a/Node/core/src/dialogs/EntityRecognizer.ts
+++ b/Node/core/src/dialogs/EntityRecognizer.ts
@@ -79,7 +79,7 @@ export class EntityRecognizer {
 
    static findListEntity(entities: IEntity<string>[], value: string): IEntity<string> {
         for (var i = 0; entities && i < entities.length; i++) {
-            if (entities[i].resolution) {
+            if (entities[i].resolution && entities[i].resolution.values) {
                 for (var j = 0; j < entities[i].resolution.values.length; j++) {
                     if (entities[i].resolution.values[j] == value) {
                         return entities[i];
@@ -103,7 +103,7 @@ export class EntityRecognizer {
     static findAllListEntities(entities: IEntity<string>[], value: string): IEntity<string>[] {
         var found: IEntity<string>[] = [];
         for (var i = 0; entities && i < entities.length; i++) {
-            if (entities[i].resolution) {
+            if (entities[i].resolution && entities[i].resolution.values) {
                 for (var j = 0; j < entities[i].resolution.values.length; j++) {
                     if (entities[i].resolution.values[j] == value) {
                         found.push(entities[i]);

--- a/Node/core/src/interfaces.d.ts
+++ b/Node/core/src/interfaces.d.ts
@@ -250,7 +250,8 @@ interface IEntity<T> {
     endIndex?: number;
     score?: number;
     resolution?: {
-        values?: string|string[];
+        value?: string;
+        values?: string[];
     }
 }
 

--- a/Node/core/src/interfaces.d.ts
+++ b/Node/core/src/interfaces.d.ts
@@ -249,6 +249,9 @@ interface IEntity<T> {
     startIndex?: number;
     endIndex?: number;
     score?: number;
+    resolution?: {
+        values?: string|string[];
+    }
 }
 
 type TextType = string|string[];


### PR DESCRIPTION
LUIS's List Entities return in a slightly different format than normal entities, they have an additional `"resolution"` property which contains another key-value pair: the key `"values"` and an array of strings. These strings can be construed as the true value a developer is looking for, opposed to the List Entity name. 

The methods are `findListEntity()` and `findAllListEntities()`.
 
This is a link to the current API docs regarding [**List Entities**](https://dev.projectoxford.ai/docs/services/5890b47c39e2bb17b84a55ff/operations/5890b47c39e2bb052c5b9c14).

##### Example List Entity from LUIS:

    {
      "entity": "ice cream",
      "type": "Desserts",
      "startIndex": 12,
      "endIndex": 20,
      "resolution": {
          "values": [
              "FrozenDesserts"
          ]
      }
    }