### PR TITLE
[C# SDK] Handling null text messages for LuisDialog

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/Dialogs/LuisDialog.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Dialogs/LuisDialog.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             if (winner == null)
             {
-                throw new InvalidOperationException("No winning intent selected from Luis results.");
+                new LuisServiceResult(new LuisResult(), new IntentRecommendation(string.Empty), this.services[0]);
             }
 
             if (winner.Result.Dialog?.Status == DialogResponse.DialogStatus.Question)

--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisService.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisService.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Bot.Builder.Luis
 
             var queryParameters = new List<string>();
             queryParameters.Add($"subscription-key={Uri.EscapeDataString(model.SubscriptionKey)}");
-            queryParameters.Add($"q={Uri.EscapeDataString(Query)}");
+            queryParameters.Add($"q={Uri.EscapeDataString(Query ?? string.Empty)}");
             UriBuilder builder;
 
             var id = Uri.EscapeDataString(model.ModelID);


### PR DESCRIPTION
LuisDialog throws exception if the message text is null.

I am mapping this to the empty string intent.