### PR TITLE
[Node SDK] Fix for #1530 - add check for NaN before attempting to recognize number

### DIFF
--- a/Node/core/src/dialogs/PromptNumber.ts
+++ b/Node/core/src/dialogs/PromptNumber.ts
@@ -58,7 +58,7 @@ export class PromptNumber extends Prompt<IPromptFeatures> {
 
         // Default recognizer logic
         this.onRecognize((context, cb) => {
-            if (context.message.text && !this.features.disableRecognizer) {
+            if (!isNaN(context.message.text) && !this.features.disableRecognizer) {
                 let options: IPromptNumberOptions = context.dialogData.options;
                 let entities = PromptRecognizers.recognizeNumbers(context, options);
                 let top = PromptRecognizers.findTopEntity(entities);


### PR DESCRIPTION
add check for NaN before attempting to recognize number input from Prompt.number()