### PR TITLE
[Node SDK] Fixed Chinese localization regex patterns

### DIFF
--- a/Node/core/lib/locale/zh-Hans/BotBuilder.json
+++ b/Node/core/lib/locale/zh-Hans/BotBuilder.json
@@ -10,9 +10,7 @@
     "list_or_more": ", 或",
     "confirm_yes": "是",
     "confirm_no": "不",
-    "boolean_choices": "true=y,yes,\\u662f,\\u786e\\u8ba4,\\u662f\\u7684,\\u597d\\u7684,\\u597d,\\u6ca1\\u95ee\\u9898,\\u5bf9,\\u5bf9\\u7684,\u1F44D,\u1F44C|false=n,no,\\u4e0d,\\u4e0d\\u662f,\\u4e0d\\u5bf9,\\u4e0d\\u77e5\\u9053,\\u4e0d\\u884c,\u1F44E,\u270B,\u1F590",
-    "yesExp": "^(\\u662f|\\u786e\\u8ba4|\\u662f\\u7684|\\u597d\\u7684|\\u597d|\\u6ca1\\u95ee\\u9898|\\u5bf9|\\u5bf9\\u7684)(\\W|$)",
-    "noExp": "^(\\u4e0d|\\u4e0d\\u662f|\\u4e0d\\u5bf9|\\u4e0d\\u77e5\\u9053|\\u4e0d\\u884c)(\\W|$)"
-}   
-
-
+    "boolean_choices": "true=y,yes,\u662f,\u786e\u8ba4,\u662f\u7684,\u597d\u7684,\u597d,\u6ca1\u95ee\u9898,\u5bf9,\u5bf9\u7684,\u1F44D,\u1F44C|false=n,no,\u4e0d,\u4e0d\u662f,\u4e0d\u5bf9,\u4e0d\u77e5\u9053,\u4e0d\u884c,\u1F44E,\u270B,\u1F590",
+    "yesExp": "^(\u662f|\u786e\u8ba4|\u662f\u7684|\u597d\u7684|\u597d|\u6ca1\u95ee\u9898|\u5bf9|\u5bf9\u7684)(\\W|$)",
+    "noExp": "^(\u4e0d|\u4e0d\u662f|\u4e0d\u5bf9|\u4e0d\u77e5\u9053|\u4e0d\u884c)(\\W|$)"
+}


### PR DESCRIPTION
Make BotBuilder recognize Chinese characters for boolean expressions correctly.

Referencing issue #2778 