### PR TITLE
[Node SDK] remove duplicate jwt check. fix for #2561

### DIFF
--- a/Node/calling/lib/bots/CallConnector.js
+++ b/Node/calling/lib/bots/CallConnector.js
@@ -137,7 +137,6 @@ var CallConnector = (function () {
                         var decoded = jwt.decode(token, { complete: true });
                         var secret = _this.getSecretForKey(decoded.header.kid);
                         var verified = jwt.verify(token, secret, jwtVerifyOptions);
-                        this.dispatch(req.body, callback);
                     }
                     catch (err) {
                         console.error(err.message);

--- a/Node/calling/lib/bots/CallConnector.js
+++ b/Node/calling/lib/bots/CallConnector.js
@@ -137,6 +137,7 @@ var CallConnector = (function () {
                         var decoded = jwt.decode(token, { complete: true });
                         var secret = _this.getSecretForKey(decoded.header.kid);
                         var verified = jwt.verify(token, secret, jwtVerifyOptions);
+                        this.dispatch(req.body, callback);
                     }
                     catch (err) {
                         console.error(err.message);

--- a/Node/calling/lib/bots/CallConnector.js
+++ b/Node/calling/lib/bots/CallConnector.js
@@ -12,12 +12,6 @@ var base64url = require('base64url');
 var keysLastFetched = 0;
 var cachedKeys;
 var issuer;
-var jwtVerifyOptions = {
-    audience: this.settings.appId,
-    ignoreExpiration: false,
-    ignoreNotBefore: false,
-    clockTolerance: 300
-};
 var CallConnector = (function () {
     function CallConnector(settings) {
         this.settings = settings;
@@ -129,6 +123,12 @@ var CallConnector = (function () {
                 token = auth[1];
             }
         }
+        var jwtVerifyOptions = {
+            audience: this.settings.appId,
+            ignoreExpiration: false,
+            ignoreNotBefore: false,
+            clockTolerance: 300
+        };
         var callback = this.responseCallback(req, res);
         if (token) {
             this.ensureCachedKeys(function (err, keys) {

--- a/Node/calling/lib/bots/CallConnector.js
+++ b/Node/calling/lib/bots/CallConnector.js
@@ -1,9 +1,10 @@
 "use strict";
-var request = require('request');
-var async = require('async');
-var url = require('url');
-var utils = require('../utils');
-var consts = require('../consts');
+Object.defineProperty(exports, "__esModule", { value: true });
+var request = require("request");
+var async = require("async");
+var url = require("url");
+var utils = require("../utils");
+var consts = require("../consts");
 var Busboy = require('busboy');
 var jwt = require('jsonwebtoken');
 var getPem = require('rsa-pem-from-mod-exp');
@@ -11,6 +12,12 @@ var base64url = require('base64url');
 var keysLastFetched = 0;
 var cachedKeys;
 var issuer;
+var jwtVerifyOptions = {
+    audience: this.settings.appId,
+    ignoreExpiration: false,
+    ignoreNotBefore: false,
+    clockTolerance: 300
+};
 var CallConnector = (function () {
     function CallConnector(settings) {
         this.settings = settings;
@@ -126,27 +133,19 @@ var CallConnector = (function () {
         if (token) {
             this.ensureCachedKeys(function (err, keys) {
                 if (!err) {
-                    var decoded = jwt.decode(token, { complete: true });
-                    var now = new Date().getTime() / 1000;
-                    if (decoded.payload.aud != _this.settings.appId || decoded.payload.iss != issuer ||
-                        now > decoded.payload.exp || now < decoded.payload.nbf) {
+                    try {
+                        var decoded = jwt.decode(token, { complete: true });
+                        var secret = _this.getSecretForKey(decoded.header.kid);
+                        var verified = jwt.verify(token, secret, jwtVerifyOptions);
+                    }
+                    catch (err) {
+                        console.error(err.message);
                         res.status(403);
                         res.end();
                     }
-                    else {
-                        var keyId = decoded.header.kid;
-                        var secret = _this.getSecretForKey(keyId);
-                        try {
-                            decoded = jwt.verify(token, secret);
-                            _this.dispatch(req.body, callback);
-                        }
-                        catch (err) {
-                            res.status(403);
-                            res.end();
-                        }
-                    }
                 }
                 else {
+                    console.error(err.message);
                     res.status(500);
                     res.end();
                 }

--- a/Node/calling/lib/bots/CallConnector.js
+++ b/Node/calling/lib/bots/CallConnector.js
@@ -137,6 +137,7 @@ var CallConnector = (function () {
                         var decoded = jwt.decode(token, { complete: true });
                         var secret = _this.getSecretForKey(decoded.header.kid);
                         var verified = jwt.verify(token, secret, jwtVerifyOptions);
+                        _this.dispatch(req.body, callback);
                     }
                     catch (err) {
                         console.error(err.message);

--- a/Node/calling/src/bots/CallConnector.ts
+++ b/Node/calling/src/bots/CallConnector.ts
@@ -49,12 +49,6 @@ var base64url = require('base64url');
 var keysLastFetched = 0;
 var cachedKeys: IKey[];
 var issuer: string;
-const jwtVerifyOptions = {
-    audience: this.settings.appId,
-    ignoreExpiration: false,
-    ignoreNotBefore: false,
-    clockTolerance: 300
-};
 
 export interface ICallConnectorSettings {
     callbackUrl: string;
@@ -193,6 +187,13 @@ export class CallConnector implements ucb.ICallConnector, bs.IBotStorage {
                 token = auth[1];
             }
         }
+
+        const jwtVerifyOptions = {
+            audience: this.settings.appId,
+            ignoreExpiration: false,
+            ignoreNotBefore: false,
+            clockTolerance: 300
+        };
 
         // Verify token
         var callback = this.responseCallback(req, res);

--- a/Node/calling/src/bots/CallConnector.ts
+++ b/Node/calling/src/bots/CallConnector.ts
@@ -204,6 +204,7 @@ export class CallConnector implements ucb.ICallConnector, bs.IBotStorage {
                         const decoded = jwt.decode(token, { complete: true });
                         const secret = this.getSecretForKey(decoded.header.kid);
                         const verified = jwt.verify(token, secret, jwtVerifyOptions);
+                        this.dispatch(req.body, callback);
                     } catch (err) {
                         console.error(err.message);
                         res.status(403);

--- a/Node/calling/src/bots/CallConnector.ts
+++ b/Node/calling/src/bots/CallConnector.ts
@@ -49,6 +49,12 @@ var base64url = require('base64url');
 var keysLastFetched = 0;
 var cachedKeys: IKey[];
 var issuer: string;
+const jwtVerifyOptions = {
+    audience: this.settings.appId,
+    ignoreExpiration: false,
+    ignoreNotBefore: false,
+    clockTolerance: 300
+};
 
 export interface ICallConnectorSettings {
     callbackUrl: string;
@@ -193,35 +199,17 @@ export class CallConnector implements ucb.ICallConnector, bs.IBotStorage {
         if (token) {
             this.ensureCachedKeys((err, keys) => {
                 if (!err) {
-                    var decoded = jwt.decode(token, { complete: true });
-                    var now = new Date().getTime() / 1000;
-
-                    // verify appId, issuer, token expirs and token notBefore
-                    if (decoded.payload.aud != this.settings.appId || decoded.payload.iss != issuer || 
-                        now > decoded.payload.exp || now < decoded.payload.nbf) {
+                    try {
+                        const decoded = jwt.decode(token, { complete: true });
+                        const secret = this.getSecretForKey(decoded.header.kid);
+                        const verified = jwt.verify(token, secret, jwtVerifyOptions);
+                    } catch (err) {
+                        console.error(err.message);
                         res.status(403);
-                        res.end();   
-                    } else {
-                        var keyId = decoded.header.kid;
-                        var secret = this.getSecretForKey(keyId);
-
-                        try {
-
-                            let jwtVerifyOptions = {
-                                audience: this.settings.appId,
-                                ignoreExpiration: false,
-                                ignoreNotBefore: false,
-                                clockTolerance: 300
-                            };
-
-                            decoded = jwt.verify(token, secret, jwtVerifyOptions);
-                            this.dispatch(req.body, callback);
-                        } catch(err) {
-                            res.status(403);
-                            res.end();     
-                        }
+                        res.end();
                     }
                 } else {
+                    console.error(err.message);
                     res.status(500);
                     res.end();
                 }


### PR DESCRIPTION
This PR removes the duplicate JWT verification and relies solely on the implementation in `jsonwebtoken` using the already existing `jwtVerifyOptions`

I also added a call to `console.error` when the connector encounters a token error, in order to provide feedback for otherwise mysterious hangups.

CallConnector.js was built using tsc 2.3.2