### PR TITLE
[C# SDK] Allow partial matches when recognizing choices in a PromptChoice

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/Dialogs/PromptDialog.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Dialogs/PromptDialog.cs
@@ -970,7 +970,8 @@ namespace Microsoft.Bot.Builder.Dialogs
                     T topEntity = default(T);
                     if (recognizeChoices)
                     {
-                        var entityMatches = this.promptOptions.Recognizer.RecognizeChoices<T>(message, this.promptOptions.Choices);
+                        var options = new PromptRecognizeChoicesOptions { AllowPartialMatches = true };
+                        var entityMatches = this.promptOptions.Recognizer.RecognizeChoices<T>(message, this.promptOptions.Choices, options);
                         var entityWinner = entityMatches.MaxBy(x => x.Score) ?? new RecognizeEntity<T>();
                         topScore = entityWinner.Score;
                         topEntity = entityWinner.Entity;

--- a/CSharp/Tests/Microsoft.Bot.Builder.Tests/PromptTests.cs
+++ b/CSharp/Tests/Microsoft.Bot.Builder.Tests/PromptTests.cs
@@ -314,6 +314,13 @@ namespace Microsoft.Bot.Builder.Tests
             await PromptSuccessAsync((context, resume) => PromptDialog.Choice(context, resume, choices, PromptText, promptStyle: PromptStyle.None), "9", "9");
         }
 
+        [TestMethod]
+        public async Task PromptSuccess_Choice_PartialMatch()
+        {
+            var choices = new[] { "hotel resort", "hotel spa", "hotel premium" };
+            await PromptSuccessAsync((context, resume) => PromptDialog.Choice(context, resume, choices, PromptText, promptStyle: PromptStyle.None), "resort", "hotel resort");
+        }
+
         public TestContext TestContext { get; set; }
 
         [TestMethod]


### PR DESCRIPTION
@msft-shahins FYI

Related to https://stackoverflow.com/questions/44241355/botframework-promptdialog-choice-no-longer-returns-partial-matches