### PR TITLE
[Node SDK] Fix Prompt IIntentRecognizerResult

### DIFF
--- a/Node/core/lib/dialogs/Prompt.js
+++ b/Node/core/lib/dialogs/Prompt.js
@@ -105,7 +105,7 @@ var Prompt = (function (_super) {
         }
         var idx = 0;
         var handlers = this._onRecognize;
-        var result = context.intent || { score: 0.0, intent: null };
+        var result = { score: 0.0, intent: null };
         function next() {
             try {
                 if (idx < handlers.length) {

--- a/Node/core/src/dialogs/Prompt.ts
+++ b/Node/core/src/dialogs/Prompt.ts
@@ -1,15 +1,15 @@
-// 
+//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
-// 
+//
 // Microsoft Bot Framework: http://botframework.com
-// 
+//
 // Bot Builder SDK Github:
 // https://github.com/Microsoft/BotBuilder
-// 
+//
 // Copyright (c) Microsoft Corporation
 // All rights reserved.
-// 
+//
 // MIT License:
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -18,10 +18,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -124,7 +124,7 @@ export class Prompt<T extends IPromptFeatures>  extends Dialog {
         if (!options.libraryNamespace) {
             if (options.localizationNamespace) {
                 // Legacy name used
-                options.libraryNamespace = options.localizationNamespace;   
+                options.libraryNamespace = options.localizationNamespace;
             } else {
                 const stack = session.dialogStack()
                 if (stack.length >= 2) {
@@ -170,7 +170,7 @@ export class Prompt<T extends IPromptFeatures>  extends Dialog {
 
         let idx = 0;
         const handlers = this._onRecognize;
-        let result: IIntentRecognizerResult = context.intent || { score: 0.0, intent: null };
+        let result: IIntentRecognizerResult = { score: 0.0, intent: null };
         function next() {
             try {
                 if (idx < handlers.length) {


### PR DESCRIPTION
Fix Prompt dialog that cannot be interrupted by global action with LUIS intent.
Referencing issue #2839