### PR TITLE
Refactor LuisModelAttribute to support third-party implementations

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisModel.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisModel.cs
@@ -52,6 +52,12 @@ namespace Microsoft.Bot.Builder.Luis
     /// </summary>
     public interface ILuisModel
     {
+/// <summary>
+        /// Domain where LUIS application is located.
+        /// </summary>
+        /// <remarks>Null means default which is api.projectoxford.ai for V1 API and westus.api.cognitive.microsoft.com for V2 api.</remarks>
+        string Domain { get; }
+
         /// <summary>
         /// Indicates if this query can be logged by LUIS.
         /// </summary>
@@ -76,11 +82,6 @@ namespace Microsoft.Bot.Builder.Luis
         /// The LUIS subscription key.
         /// </summary>
         string SubscriptionKey { get; }
-
-        /// <summary>
-        /// The base Uri for accessing LUIS.
-        /// </summary>
-        Uri UriBase { get; }
 
         /// <summary>
         /// Return verbose results from a query.
@@ -118,12 +119,6 @@ namespace Microsoft.Bot.Builder.Luis
         /// </summary>
         /// <remarks>Null means default which is api.projectoxford.ai for V1 API and westus.api.cognitive.microsoft.com for V2 api.</remarks>
         public string Domain => domain;
-
-        private readonly Uri uriBase;
-        /// <summary>
-        /// Base URI for LUIS calls.
-        /// </summary>
-        public Uri UriBase => uriBase;
 
         private readonly LuisApiVersion apiVersion;
         /// <summary>
@@ -173,15 +168,10 @@ namespace Microsoft.Bot.Builder.Luis
             SetField.NotNull(out this.modelID, nameof(modelID), modelID);
             SetField.NotNull(out this.subscriptionKey, nameof(subscriptionKey), subscriptionKey);
             this.apiVersion = apiVersion;
-            if (domain == null)
-            {
-                domain = apiVersion == LuisApiVersion.V2 ? "westus.api.cognitive.microsoft.com" : "api.projectoxford.ai/luis/v1/application";
-            }
             this.log = log;
             this.domain = domain;
             this.spellCheck = spellCheck;
             this.staging = staging;
-            this.uriBase = new Uri(apiVersion == LuisApiVersion.V2 ? $"https://{domain}/luis/v2.0/apps/" : $"https://api.projectoxford.ai/luis/v1/application");
             this.verbose = verbose;
         }
 
@@ -191,7 +181,6 @@ namespace Microsoft.Bot.Builder.Luis
                 && object.Equals(this.ModelID, other.ModelID)
                 && object.Equals(this.SubscriptionKey, other.SubscriptionKey)
                 && object.Equals(this.ApiVersion, other.ApiVersion)
-                && object.Equals(this.UriBase, other.UriBase)
                 ;
         }
 
@@ -204,7 +193,6 @@ namespace Microsoft.Bot.Builder.Luis
         {
             return ModelID.GetHashCode()
                 ^ SubscriptionKey.GetHashCode()
-                ^ UriBase.GetHashCode()
                 ^ ApiVersion.GetHashCode();
         }
     }

--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisModel.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisModel.cs
@@ -91,13 +91,6 @@ namespace Microsoft.Bot.Builder.Luis
         /// Luis Api Version.
         /// </summary>
         LuisApiVersion ApiVersion { get; }
-
-        /// <summary>
-        /// Modify a Luis request to specify query parameters like spelling or logging.
-        /// </summary>
-        /// <param name="request">Request so far.</param>
-        /// <returns>Modified request.</returns>
-        LuisRequest ModifyRequest(LuisRequest request);
     }
 
     /// <summary>
@@ -213,24 +206,6 @@ namespace Microsoft.Bot.Builder.Luis
                 ^ SubscriptionKey.GetHashCode()
                 ^ UriBase.GetHashCode()
                 ^ ApiVersion.GetHashCode();
-        }
-
-        public LuisRequest ModifyRequest(LuisRequest request)
-        {
-            request.Log = log;
-            if (SpellCheck)
-            {
-                request.SpellCheck = true;
-            }
-            if (Staging)
-            {
-                request.Staging = true;
-            }
-            if (Verbose)
-            {
-                request.Verbose = true;
-            }
-            return request;
         }
     }
 }

--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisModel.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisModel.cs
@@ -53,9 +53,24 @@ namespace Microsoft.Bot.Builder.Luis
     public interface ILuisModel
     {
         /// <summary>
+        /// Indicates if this query can be logged by LUIS.
+        /// </summary>
+        bool Log { get; }
+
+        /// <summary>
         /// The LUIS model ID.
         /// </summary>
         string ModelID { get; }
+
+        /// <summary>
+        /// Control spell checking.
+        /// </summary>
+        bool SpellCheck { get; }
+
+        /// <summary>
+        /// Whether to use staging or production endpoint.
+        /// </summary>
+        bool Staging { get; }
 
         /// <summary>
         /// The LUIS subscription key.
@@ -66,6 +81,11 @@ namespace Microsoft.Bot.Builder.Luis
         /// The base Uri for accessing LUIS.
         /// </summary>
         Uri UriBase { get; }
+
+        /// <summary>
+        /// Return verbose results from a query.
+        /// </summary>
+        bool Verbose { get; }
 
         /// <summary>
         /// Luis Api Version.

--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisModel.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisModel.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Bot.Builder.Luis
     /// </summary>
     public interface ILuisModel
     {
-/// <summary>
+        /// <summary>
         /// Domain where LUIS application is located.
         /// </summary>
         /// <remarks>Null means default which is api.projectoxford.ai for V1 API and westus.api.cognitive.microsoft.com for V2 api.</remarks>

--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisService.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisService.cs
@@ -249,7 +249,20 @@ namespace Microsoft.Bot.Builder.Luis
 
         public LuisRequest ModifyRequest(LuisRequest request)
         {
-            return model.ModifyRequest(request);
+            request.Log = model.Log;
+            if (model.SpellCheck)
+            {
+                request.SpellCheck = true;
+            }
+            if (model.Staging)
+            {
+                request.Staging = true;
+            }
+            if (model.Verbose)
+            {
+                request.Verbose = true;
+            }
+            return request;
         }
 
         Uri ILuisService.BuildUri(LuisRequest luisRequest)

--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisService.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisService.cs
@@ -151,13 +151,13 @@ namespace Microsoft.Bot.Builder.Luis
             {
 #pragma warning disable CS0612
                 case LuisApiVersion.V1:
-                    builder = new UriBuilder(model.UriBase);
+                    builder = new UriBuilder(GetUriBase(model));
                     queryParameters.Add($"id={id}");
                     break;
 #pragma warning restore CS0612
                 case LuisApiVersion.V2:
                     //v2.0 have the model as path parameter
-                    builder = new UriBuilder(new Uri(model.UriBase, id));
+                    builder = new UriBuilder(new Uri(GetUriBase(model), id));
                     break;
                 default:
                     throw new ArgumentException($"{model.ApiVersion} is not a valid Luis api version.");
@@ -199,6 +199,17 @@ namespace Microsoft.Bot.Builder.Luis
             }
             builder.Query = string.Join("&", queryParameters);
             return builder.Uri;
+        }
+
+        private Uri GetUriBase(ILuisModel model)
+        {
+            var apiVersion = model.ApiVersion;
+            var domain = model.Domain;
+            if (domain == null)
+            {
+                domain = apiVersion == LuisApiVersion.V2 ? "westus.api.cognitive.microsoft.com" : "api.projectoxford.ai/luis/v1/application";
+            }
+            return new Uri(apiVersion == LuisApiVersion.V2 ? $"https://{domain}/luis/v2.0/apps/" : $"https://api.projectoxford.ai/luis/v1/application");
         }
     }
 


### PR DESCRIPTION
Fixes #2230. Basically, `LuisModelAttribute` contained a few domain-specific pieces of logic that prevented third parties from consuming their own implementations of `ILuisModel`. This is a small refactoring that brings some of that logic to the BF framework itself:

* Bring optional LUIS properties to `ILuisModel`
* Calculate `UriBase` in `LuisRequest`
* Move `ILuisModel.ModifyRequest` to `LuisService`