### PR TITLE
Fixed typo in CallConnector

### DIFF
--- a/Node/calling/src/bots/CallConnector.ts
+++ b/Node/calling/src/bots/CallConnector.ts
@@ -71,7 +71,7 @@ export class CallConnector implements ucb.ICallConnector, bs.IBotStorage {
     private handler: (event: IEvent, cb?: (err: Error) => void) => void;
     private accessToken: string;
     private accessTokenExpires: number;
-    private responses: { [id:string]: (err: Error, repsonse?: any) => void; } = {};
+    private responses: { [id:string]: (err: Error, response?: any) => void; } = {};
 
     constructor(private settings: ICallConnectorSettings) {
         if (!this.settings.endpoint) {


### PR DESCRIPTION
Fixed typo.
please fix [Documentation](https://docs.microsoft.com/en-us/bot-framework/nodejs/bot-builder-nodejs-dialog-manage-conversation) page too 😉