### PR TITLE
Bug Fix: One more corner case caused AnnotatedSandwitchBot Sample to …

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/FormFlow/FieldReflector.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/FormFlow/FieldReflector.cs
@@ -360,6 +360,11 @@ namespace Microsoft.Bot.Builder.FormFlow.Advanced
                 if (describe != null)
                 {
                     _description = describe;
+                    if (string.IsNullOrEmpty(_description.Description))
+                    {
+                        _description.Description = Language.CamelCase(name);
+                    }
+
                 }
                 else
                 {

--- a/CSharp/Tests/Microsoft.Bot.Builder.Tests/FormTests.cs
+++ b/CSharp/Tests/Microsoft.Bot.Builder.Tests/FormTests.cs
@@ -856,8 +856,11 @@ Is this what you wanted? {||}")
         {
             public string FieldNameWithoutAttributes { get; set; }
 
-            [Describe("FieldDescribe1")]
-            public string FieldNameWithDescribeAttributeOnly { get; set; }
+            [Describe(description:"FieldDescribeDescription1")]
+            public string FieldNameWithDescribeDescriptionAttributeOnly { get; set; }
+
+            [Describe(title: "FieldDescribeNullDescription1")]
+            public string FieldNameWithDescribeNullDescriptionAttributeOnly { get; set; }
 
             [Describe("FieldName2")]
             [Terms("FieldName2")]
@@ -897,9 +900,14 @@ Is this what you wanted? {||}")
                     Assert.IsTrue(field.FieldDescription.Description == "Field Name Without Attributes");
                     Assert.IsTrue(field.FieldTerms.Any(ft => ft.StartsWith(field.FieldDescription.Description.ToLower())));
                 }
-                else if (field.Name == "FieldNameWithDescribeAttributeOnly")
+                else if (field.Name == "FieldNameWithDescribeDescriptionAttributeOnly")
                 {
-                    Assert.IsTrue(field.FieldDescription.Description == "FieldDescribe1");
+                    Assert.IsTrue(field.FieldDescription.Description == "FieldDescribeDescription1");
+                    Assert.IsTrue(field.FieldTerms.Any(ft => ft.StartsWith(field.FieldDescription.Description.ToLower())));
+                }
+                else if (field.Name == "FieldNameWithDescribeNullDescriptionAttributeOnly")
+                {
+                    Assert.IsTrue(field.FieldDescription.Description == "Field Name With Describe Null Description Attribute Only");
                     Assert.IsTrue(field.FieldTerms.Any(ft => ft.StartsWith(field.FieldDescription.Description.ToLower())));
                 }
                 else if (field.Name == "FieldNameWithDescribeTermsAttributesSame")


### PR DESCRIPTION
…break.

if _description.Description is null then setting describe attribute's description value as field name.