### PR TITLE
[Node] Handle LUIS HTTP errors

### DIFF
--- a/Node/core/lib/dialogs/LuisRecognizer.js
+++ b/Node/core/lib/dialogs/LuisRecognizer.js
@@ -83,22 +83,20 @@ var LuisRecognizer = (function (_super) {
             request.get(url.format(uri), function (err, res, body) {
                 var result;
                 try {
-                    if (!err) {
-                        if (res.statusCode === 200) {
-                            result = JSON.parse(body);
-                            result.intents = result.intents || [];
-                            result.entities = result.entities || [];
-                            result.compositeEntities = result.compositeEntities || [];
-                            if (result.topScoringIntent && result.intents.length == 0) {
-                                result.intents.push(result.topScoringIntent);
-                            }
-                            if (result.intents.length == 1 && typeof result.intents[0].score !== 'number') {
-                                result.intents[0].score = 1.0;
-                            }
+                    if (res && res.statusCode === 200) {
+                        result = JSON.parse(body);
+                        result.intents = result.intents || [];
+                        result.entities = result.entities || [];
+                        result.compositeEntities = result.compositeEntities || [];
+                        if (result.topScoringIntent && result.intents.length == 0) {
+                            result.intents.push(result.topScoringIntent);
                         }
-                        else {
-                            err = new Error(body);
+                        if (result.intents.length == 1 && typeof result.intents[0].score !== 'number') {
+                            result.intents[0].score = 1.0;
                         }
+                    }
+                    else {
+                        err = new Error(body);
                     }
                 }
                 catch (e) {

--- a/Node/core/lib/dialogs/LuisRecognizer.js
+++ b/Node/core/lib/dialogs/LuisRecognizer.js
@@ -84,15 +84,20 @@ var LuisRecognizer = (function (_super) {
                 var result;
                 try {
                     if (!err) {
-                        result = JSON.parse(body);
-                        result.intents = result.intents || [];
-                        result.entities = result.entities || [];
-                        result.compositeEntities = result.compositeEntities || [];
-                        if (result.topScoringIntent && result.intents.length == 0) {
-                            result.intents.push(result.topScoringIntent);
+                        if (res.statusCode === 200) {
+                            result = JSON.parse(body);
+                            result.intents = result.intents || [];
+                            result.entities = result.entities || [];
+                            result.compositeEntities = result.compositeEntities || [];
+                            if (result.topScoringIntent && result.intents.length == 0) {
+                                result.intents.push(result.topScoringIntent);
+                            }
+                            if (result.intents.length == 1 && typeof result.intents[0].score !== 'number') {
+                                result.intents[0].score = 1.0;
+                            }
                         }
-                        if (result.intents.length == 1 && typeof result.intents[0].score !== 'number') {
-                            result.intents[0].score = 1.0;
+                        else {
+                            err = new Error(body);
                         }
                     }
                 }

--- a/Node/core/src/dialogs/LuisRecognizer.ts
+++ b/Node/core/src/dialogs/LuisRecognizer.ts
@@ -119,16 +119,20 @@ export class LuisRecognizer extends IntentRecognizer {
                 var result: ILuisResults;
                 try {
                     if (!err) {
-                        result = JSON.parse(body);
-                        result.intents = result.intents || [];
-                        result.entities = result.entities || [];
-                        result.compositeEntities = result.compositeEntities || [];
-                        if (result.topScoringIntent && result.intents.length == 0) {
-                            result.intents.push(result.topScoringIntent);
-                        }
-                        if (result.intents.length == 1 && typeof result.intents[0].score !== 'number') {
-                            // Intents for the builtin Cortana app don't return a score.
-                            result.intents[0].score = 1.0;
+                        if (res.statusCode === 200) {
+                            result = JSON.parse(body);
+                            result.intents = result.intents || [];
+                            result.entities = result.entities || [];
+                            result.compositeEntities = result.compositeEntities || [];
+                            if (result.topScoringIntent && result.intents.length == 0) {
+                                result.intents.push(result.topScoringIntent);
+                            }
+                            if (result.intents.length == 1 && typeof result.intents[0].score !== 'number') {
+                                // Intents for the builtin Cortana app don't return a score.
+                                result.intents[0].score = 1.0;
+                            }
+                        } else {
+                            err = new Error(body);
                         }
                     }
                 } catch (e) {

--- a/Node/core/src/dialogs/LuisRecognizer.ts
+++ b/Node/core/src/dialogs/LuisRecognizer.ts
@@ -118,22 +118,20 @@ export class LuisRecognizer extends IntentRecognizer {
                 // Parse results
                 var result: ILuisResults;
                 try {
-                    if (!err) {
-                        if (res.statusCode === 200) {
-                            result = JSON.parse(body);
-                            result.intents = result.intents || [];
-                            result.entities = result.entities || [];
-                            result.compositeEntities = result.compositeEntities || [];
-                            if (result.topScoringIntent && result.intents.length == 0) {
-                                result.intents.push(result.topScoringIntent);
-                            }
-                            if (result.intents.length == 1 && typeof result.intents[0].score !== 'number') {
-                                // Intents for the builtin Cortana app don't return a score.
-                                result.intents[0].score = 1.0;
-                            }
-                        } else {
-                            err = new Error(body);
+                    if (res && res.statusCode === 200) {
+                        result = JSON.parse(body);
+                        result.intents = result.intents || [];
+                        result.entities = result.entities || [];
+                        result.compositeEntities = result.compositeEntities || [];
+                        if (result.topScoringIntent && result.intents.length == 0) {
+                            result.intents.push(result.topScoringIntent);
                         }
+                        if (result.intents.length == 1 && typeof result.intents[0].score !== 'number') {
+                            // Intents for the builtin Cortana app don't return a score.
+                            result.intents[0].score = 1.0;
+                        }
+                    } else {
+                        err = new Error(body);
                     }
                 } catch (e) {
                     err = e;


### PR DESCRIPTION
Handle LUIS HTTP errors, so the bot can know that anything went wrong. For example if the URL has `http` protocol instead of `https`, the bot gets a 404, if the subscription key is wrong, the bot gets a 401, but in both cases, it thinks that everything went ok, with a result `{ score: 0, intent: null, intents: [], entities: [] }`