### PR TITLE
[.NET] Properties set for ILuisModel are not taken into account

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisService.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisService.cs
@@ -281,7 +281,8 @@ namespace Microsoft.Bot.Builder.Luis
         /// <returns>The LUIS result.</returns>
         public static async Task<LuisResult> QueryAsync(this ILuisService service, string text, CancellationToken token)
         {
-            return await service.QueryAsync(new LuisRequest(query: text), token);
+            var luisRequest = service.ModifyRequest(new LuisRequest(query: text));
+            return await service.QueryAsync(luisRequest, token);
         }
 
         /// <summary>

--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisService.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisService.cs
@@ -293,6 +293,7 @@ namespace Microsoft.Bot.Builder.Luis
         /// <returns>LUIS result.</returns>
         public static async Task<LuisResult> QueryAsync(this ILuisService service, LuisRequest request, CancellationToken token)
         {
+            service.ModifyRequest(request);
             var uri = service.BuildUri(request);
             return await service.QueryAsync(uri, token);
         }


### PR DESCRIPTION
After update to Bot.Builder 3.8.2:
If you create Luis Service this way:
`new LuisService(new LuisModelAttribute("id","key") { Verbose = true})`

your uri to luis won't take Verbose into account, and your url will be like:

https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/x?subscription-key=y&q=query&log=True

instead of:
https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/x?subscription-key=y&verbose=true&q=query&log=True

Issue #3033