### PR TITLE
Add processEvent to ConsoleConnector

### DIFF
--- a/Node/core/lib/bots/ConsoleConnector.js
+++ b/Node/core/lib/bots/ConsoleConnector.js
@@ -39,6 +39,12 @@ var ConsoleConnector = (function () {
         }
         return this;
     };
+    ConsoleConnector.prototype.processEvent = function (event) {
+        if (this.onEventHandler) {
+            this.onEventHandler([event]);
+        }
+        return this;
+    };
     ConsoleConnector.prototype.onEvent = function (handler) {
         this.onEventHandler = handler;
     };

--- a/Node/core/src/bots/ConsoleConnector.ts
+++ b/Node/core/src/bots/ConsoleConnector.ts
@@ -75,6 +75,13 @@ export class ConsoleConnector implements IConnector {
         return this;
     }
 
+    public processEvent(event: IEvent): this {
+        if (this.onEventHandler) {
+            this.onEventHandler([event]);
+        }
+        return this;
+    }
+
     public onEvent(handler: (events: IEvent[], cb?: (err: Error) => void) => void): void {
         this.onEventHandler = handler;
     }


### PR DESCRIPTION
At the moment the only events that can be processed with the
ConsoleConnector are messages with very restricted configuration. By
adding a processEvent method any event can be tested including messages
with custom sourceEvent setups for real client dependent (Slack, MS
Teams, etc) tests.