### PR TITLE
[Node SDK] create new object for exec in RegExpRecognizer

### DIFF
--- a/Node/core/lib/dialogs/RegExpRecognizer.js
+++ b/Node/core/lib/dialogs/RegExpRecognizer.js
@@ -31,7 +31,7 @@ var RegExpRecognizer = (function (_super) {
             var locale = context.locale || '*';
             var exp = this.expressions.hasOwnProperty(locale) ? this.expressions[locale] : this.expressions['*'];
             if (exp) {
-                var matches = exp.exec(context.message.text);
+                var matches = new RegExp(exp).exec(context.message.text);
                 if (matches && matches.length) {
                     var matched = matches[0];
                     result.score = 0.4 + ((matched.length / context.message.text.length) * 0.6);

--- a/Node/core/src/dialogs/RegExpRecognizer.ts
+++ b/Node/core/src/dialogs/RegExpRecognizer.ts
@@ -57,7 +57,7 @@ export class RegExpRecognizer extends IntentRecognizer {
             var locale = context.locale || '*';
             var exp = this.expressions.hasOwnProperty(locale) ? this.expressions[locale] : this.expressions['*'];
             if (exp) {
-                var matches = exp.exec(context.message.text);
+                var matches = new RegExp(exp).exec(context.message.text);
                 if (matches && matches.length) {
                     // Score is coverage on a scale of 0.4 - 1.0.
                     var matched = matches[0];


### PR DESCRIPTION
Calling exec on a `RegExp` object returns null every second time for matches

<img width="210" alt="screen shot 2017-07-11 at 12 09 24 pm" src="https://user-images.githubusercontent.com/16324837/28055069-ff4cc34e-6634-11e7-9bba-19ab997dab43.png">

which makes recognizer fail every second time if the RegExps are specified as literals

```
bot.recognizer(new RegExpRecognizer('...', {
  '*': /.../,
});
```

This prevents that by creating a new RegExp object every time for exec
