### PR TITLE
Update Store.cs

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/Fibers/Store.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Fibers/Store.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Bot.Builder.Internals.Fibers
             {
                 return this.store.TryLoad(out item);
             }
-            catch (Exception)
+            catch (Exception exc)
             {
                 System.Diagnostics.Trace.TraceError($"Exception on deserializing stored data! Stack has been cleared. Details: {exc}");
                 // exception in loading the serialized data

--- a/CSharp/Library/Microsoft.Bot.Builder/Fibers/Store.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Fibers/Store.cs
@@ -109,6 +109,7 @@ namespace Microsoft.Bot.Builder.Internals.Fibers
             }
             catch (Exception)
             {
+                System.Diagnostics.Trace.TraceError($"Exception on deserializing stored data! Stack has been cleared. Details: {exc}");
                 // exception in loading the serialized data
                 item = default(T);
                 return false;


### PR DESCRIPTION
There's no evidence about a wrong deserialization of the stored informations, due to a potentially missing external libraries or a field which cannot be deserialized properly.
In case of an exception, the navigation stack  is cleared without any clue about it.
I created a Dialog, and I put an unserializable private field into it... I spent 2 hours in order to discover why the dialog were lost. I have to  download the botbuilder source code, and use it in order to undesrtand what's wrong.