### PR TITLE
Fix NullReference when starting FormFlow with FormOptions.PromptInStart

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/FormFlow/FormDialog.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/FormFlow/FormDialog.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Bot.Builder.FormFlow
         {
             try
             {
-                var message = await toBot;
+                var message = toBot == null ? null : await toBot;
 
                 // Ensure we have initial definition for field steps
                 foreach (var step in _form.Steps)


### PR DESCRIPTION
Fix NullReference introduced in 3.8.5 when starting FormFlow with FormOptions.PromptInStart.
Fixes the following issues:
- https://github.com/Microsoft/BotBuilder/issues/3157
- https://github.com/Microsoft/BotBuilder/issues/3159
- https://github.com/Microsoft/BotBuilder/issues/3153