### PR TITLE
skip empty string for  openIdConfigurationUrl

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Connector.NetFramework/BotAuthentication.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.NetFramework/BotAuthentication.cs
@@ -129,7 +129,8 @@ namespace Microsoft.Bot.Connector
 
         private string GetOpenIdConfigurationUrl()
         {
-            return settingsOpenIdConfigurationurl.Value ?? this.OpenIdConfigurationUrl;
+            var settingsUrl = settingsOpenIdConfigurationurl.Value;
+            return  string.IsNullOrEmpty(settingsUrl) ? this.OpenIdConfigurationUrl : settingsUrl;
         }
     }
 }


### PR DESCRIPTION
Handle empty string value openIdConfigurationUrl from settings the same way we handle null.