### PR TITLE
[.NET SDK] Update ActivityEx.cs mark GetStateClient() as Deprecated

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ActivityEx.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ActivityEx.cs
@@ -215,6 +215,7 @@ namespace Microsoft.Bot.Connector
         /// <param name="handlers"></param>
         /// <param name="activity"></param>
         /// <returns></returns>
+        [System.Obsolete("Depreciated: This method will only get the default state client, if you have implemented a custom state client it will not retrieve it")]
         public static StateClient GetStateClient(this IActivity activity, MicrosoftAppCredentials credentials, string serviceUrl = null, params DelegatingHandler[] handlers)
         {
             bool useServiceUrl = (activity.ChannelId == "emulator");

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ActivityEx.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ActivityEx.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Bot.Connector
         /// <param name="handlers"></param>
         /// <param name="activity"></param>
         /// <returns></returns>
-        [System.Obsolete("Depreciated: This method will only get the default state client, if you have implemented a custom state client it will not retrieve it")]
+        [System.Obsolete("Deprecated: This method will only get the default state client, if you have implemented a custom state client it will not retrieve it")]
         public static StateClient GetStateClient(this IActivity activity, MicrosoftAppCredentials credentials, string serviceUrl = null, params DelegatingHandler[] handlers)
         {
             bool useServiceUrl = (activity.ChannelId == "emulator");


### PR DESCRIPTION
This method causes a lot of confusion for people using custom state clients.