### PR TITLE
[Node.js SDK] fix bot.loadSession to use dispatch by default

### DIFF
--- a/Node/core/lib/bots/UniversalBot.js
+++ b/Node/core/lib/bots/UniversalBot.js
@@ -250,7 +250,7 @@ var UniversalBot = (function (_super) {
         this._onDisambiguateRoute = handler;
     };
     UniversalBot.prototype.loadSession = function (address, done) {
-        this.loadSessionWithOptionalDispatch(address, false, done);
+        this.loadSessionWithOptionalDispatch(address, true, done);
     };
     UniversalBot.prototype.loadSessionWithoutDispatching = function (address, done) {
         this.loadSessionWithOptionalDispatch(address, false, done);

--- a/Node/core/src/bots/UniversalBot.ts
+++ b/Node/core/src/bots/UniversalBot.ts
@@ -335,7 +335,7 @@ export class UniversalBot extends Library {
     
     /** Loads a session object for an arbitrary address. */
     public loadSession(address: IAddress, done: (err: Error, session: Session) => void): void {
-        this.loadSessionWithOptionalDispatch(address, false, done);
+        this.loadSessionWithOptionalDispatch(address, true, done);
     }
 
     public loadSessionWithoutDispatching(address: IAddress, done: (err: Error, session: Session) => void): void {


### PR DESCRIPTION
Addresses #3508, which arose from #3396  