### PR TITLE
Support for Bot Framework Auth v3.2

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder.Autofac/Properties/AssemblyInfo.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Autofac/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.9.1.0")]
-[assembly: AssemblyFileVersion("3.9.1.0")]
+[assembly: AssemblyVersion("3.10.5.0")]
+[assembly: AssemblyFileVersion("3.10.5.0")]
 
 [assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Tests")]
 [assembly: InternalsVisibleTo("Microsoft.Bot.Sample.Tests")]

--- a/CSharp/Library/Microsoft.Bot.Builder/Properties/AssemblyInfo.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Properties/AssemblyInfo.cs
@@ -33,8 +33,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.9.1.0")]
-[assembly: AssemblyFileVersion("3.9.1.0")]
+[assembly: AssemblyVersion("3.10.5.0")]
+[assembly: AssemblyFileVersion("3.10.5.0")]
 
 [assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Tests")]
 [assembly: InternalsVisibleTo("Microsoft.Bot.Sample.Tests")]

--- a/CSharp/Library/Microsoft.Bot.Connector.NetFramework/Properties/AssemblyInfo.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.NetFramework/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("3.9.1.0")]
-[assembly: AssemblyFileVersion("3.9.1.0")]
+[assembly: AssemblyVersion("3.10.5.0")]
+[assembly: AssemblyFileVersion("3.10.5.0")]

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/JwtConfig.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/JwtConfig.cs
@@ -60,7 +60,6 @@
             {
                 ValidateIssuer = true,
                 ValidIssuers = new[] {
-                    "https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/",                    // Auth v3.0, 1.0 token
                     "https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/",                    // Auth v3.1, 1.0 token
                     "https://login.microsoftonline.com/d6d49420-f39b-4df7-a1dc-d59a935871db/v2.0",      // Auth v3.1, 2.0 token
                     "https://sts.windows.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a/",                    // Auth v3.2, 1.0 token

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/JwtConfig.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/JwtConfig.cs
@@ -59,7 +59,13 @@
             new TokenValidationParameters()
             {
                 ValidateIssuer = true,
-                ValidIssuers = new[] { "https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/", "https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/", "https://login.microsoftonline.com/d6d49420-f39b-4df7-a1dc-d59a935871db/v2.0" },
+                ValidIssuers = new[] {
+                    "https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/",                    // Auth v3.0, 1.0 token
+                    "https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/",                    // Auth v3.1, 1.0 token
+                    "https://login.microsoftonline.com/d6d49420-f39b-4df7-a1dc-d59a935871db/v2.0",      // Auth v3.1, 2.0 token
+                    "https://sts.windows.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a/",                    // Auth v3.2, 1.0 token
+                    "https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0"       // Auth v3.2, 2.0 token
+                },
                 // Audience validation takes place in JwtTokenExtractor
                 ValidateAudience = false,
                 ValidateLifetime = true,

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/JwtTokenExtractor.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/JwtTokenExtractor.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Bot.Connector
             if (appIdClaim == null)
                 return null;
 
-            // v3.1 emulator token
+            // v3.1 or v3.2 emulator token
             if (identity.Claims.Any(c => c.Type == "aud" && c.Value == appIdClaim.Value))
                 return appIdClaim.Value;
 

--- a/Node/core/lib/bots/ChatConnector.js
+++ b/Node/core/lib/bots/ChatConnector.js
@@ -23,9 +23,6 @@ var ChatConnector = (function () {
                 botConnectorOpenIdMetadata: this.settings.openIdMetadata || 'https://login.botframework.com/v1/.well-known/openidconfiguration',
                 botConnectorIssuer: 'https://api.botframework.com',
                 botConnectorAudience: this.settings.appId,
-                msaOpenIdMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
-                msaIssuer: 'https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/',
-                msaAudience: 'https://graph.microsoft.com',
                 emulatorOpenIdMetadata: 'https://login.microsoftonline.com/botframework.com/v2.0/.well-known/openid-configuration',
                 emulatorAudience: this.settings.appId,
                 emulatorAuthV31IssuerV1: 'https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/',
@@ -36,7 +33,6 @@ var ChatConnector = (function () {
             };
         }
         this.botConnectorOpenIdMetadata = new OpenIdMetadata_1.OpenIdMetadata(this.settings.endpoint.botConnectorOpenIdMetadata);
-        this.msaOpenIdMetadata = new OpenIdMetadata_1.OpenIdMetadata(this.settings.endpoint.msaOpenIdMetadata);
         this.emulatorOpenIdMetadata = new OpenIdMetadata_1.OpenIdMetadata(this.settings.endpoint.emulatorOpenIdMetadata);
     }
     ChatConnector.prototype.listen = function () {
@@ -81,38 +77,27 @@ var ChatConnector = (function () {
                     res.end();
                     return;
                 }
-                if (decoded_1.payload.iss == this.settings.endpoint.msaIssuer) {
-                    openIdMetadata = this.msaOpenIdMetadata;
+                var issuer = void 0;
+                if (decoded_1.payload.ver === '1.0' && decoded_1.payload.iss == this.settings.endpoint.emulatorAuthV31IssuerV1) {
+                    issuer = this.settings.endpoint.emulatorAuthV31IssuerV1;
+                }
+                else if (decoded_1.payload.ver === '2.0' && decoded_1.payload.iss == this.settings.endpoint.emulatorAuthV31IssuerV2) {
+                    issuer = this.settings.endpoint.emulatorAuthV31IssuerV2;
+                }
+                else if (decoded_1.payload.ver === '1.0' && decoded_1.payload.iss == this.settings.endpoint.emulatorAuthV32IssuerV1) {
+                    issuer = this.settings.endpoint.emulatorAuthV32IssuerV1;
+                }
+                else if (decoded_1.payload.ver === '2.0' && decoded_1.payload.iss == this.settings.endpoint.emulatorAuthV32IssuerV2) {
+                    issuer = this.settings.endpoint.emulatorAuthV32IssuerV2;
+                }
+                if (issuer) {
+                    openIdMetadata = this.emulatorOpenIdMetadata;
                     verifyOptions = {
                         algorithms: algorithms,
-                        issuer: this.settings.endpoint.msaIssuer,
-                        audience: this.settings.endpoint.msaAudience,
+                        issuer: issuer,
+                        audience: this.settings.endpoint.emulatorAudience,
                         clockTolerance: 300
                     };
-                }
-                else {
-                    var issuer = void 0;
-                    if (decoded_1.payload.ver === '1.0' && decoded_1.payload.iss == this.settings.endpoint.emulatorAuthV31IssuerV1) {
-                        issuer = this.settings.endpoint.emulatorAuthV31IssuerV1;
-                    }
-                    else if (decoded_1.payload.ver === '2.0' && decoded_1.payload.iss == this.settings.endpoint.emulatorAuthV31IssuerV2) {
-                        issuer = this.settings.endpoint.emulatorAuthV31IssuerV2;
-                    }
-                    else if (decoded_1.payload.ver === '1.0' && decoded_1.payload.iss == this.settings.endpoint.emulatorAuthV32IssuerV1) {
-                        issuer = this.settings.endpoint.emulatorAuthV32IssuerV1;
-                    }
-                    else if (decoded_1.payload.ver === '2.0' && decoded_1.payload.iss == this.settings.endpoint.emulatorAuthV32IssuerV2) {
-                        issuer = this.settings.endpoint.emulatorAuthV32IssuerV2;
-                    }
-                    if (issuer) {
-                        openIdMetadata = this.emulatorOpenIdMetadata;
-                        verifyOptions = {
-                            algorithms: algorithms,
-                            issuer: issuer,
-                            audience: this.settings.endpoint.emulatorAudience,
-                            clockTolerance: 300
-                        };
-                    }
                 }
             }
             if (!verifyOptions) {

--- a/Node/core/lib/bots/Library.js
+++ b/Node/core/lib/bots/Library.js
@@ -471,13 +471,13 @@ var Library = (function (_super) {
     Library.prototype.logPrefix = function () {
         return 'Library("' + this.name + '")';
     };
-    Library.RouteTypes = {
-        GlobalAction: 'GlobalAction',
-        StackAction: 'StackAction',
-        ActiveDialog: 'ActiveDialog'
-    };
     return Library;
 }(events_1.EventEmitter));
+Library.RouteTypes = {
+    GlobalAction: 'GlobalAction',
+    StackAction: 'StackAction',
+    ActiveDialog: 'ActiveDialog'
+};
 exports.Library = Library;
 exports.systemLib = new Library(consts.Library.system);
 exports.systemLib.localePath(path.join(__dirname, '../locale/'));

--- a/Node/core/lib/deprecated/LegacyPrompts.js
+++ b/Node/core/lib/deprecated/LegacyPrompts.js
@@ -249,19 +249,19 @@ var LegacyPrompts = (function (_super) {
             }
         }
     };
-    LegacyPrompts.options = {
-        recognizer: new SimplePromptRecognizer(),
-        promptAfterAction: true
-    };
-    LegacyPrompts.defaultRetryPrompt = {
-        text: "default_text",
-        number: "default_number",
-        confirm: "default_confirm",
-        choice: "default_choice",
-        time: "default_time",
-        attachment: "default_file"
-    };
     return LegacyPrompts;
 }(Dialog_1.Dialog));
+LegacyPrompts.options = {
+    recognizer: new SimplePromptRecognizer(),
+    promptAfterAction: true
+};
+LegacyPrompts.defaultRetryPrompt = {
+    text: "default_text",
+    number: "default_number",
+    confirm: "default_confirm",
+    choice: "default_choice",
+    time: "default_time",
+    attachment: "default_file"
+};
 exports.LegacyPrompts = LegacyPrompts;
 Library_1.systemLib.dialog('BotBuilder:Prompts', new LegacyPrompts());

--- a/Node/core/lib/dialogs/EntityRecognizer.js
+++ b/Node/core/lib/dialogs/EntityRecognizer.js
@@ -211,11 +211,11 @@ var EntityRecognizer = (function () {
             return [choices.toString()];
         }
     };
-    EntityRecognizer.dateExp = /^\d{4}-\d{2}-\d{2}/i;
-    EntityRecognizer.yesExp = /^(1|y|yes|yep|sure|ok|true)(\W|$)/i;
-    EntityRecognizer.noExp = /^(2|n|no|nope|not|false)(\W|$)/i;
-    EntityRecognizer.numberExp = /[+-]?(?:\d+\.?\d*|\d*\.?\d+)/;
-    EntityRecognizer.ordinalWords = 'first|second|third|fourth|fifth|sixth|seventh|eigth|ninth|tenth';
     return EntityRecognizer;
 }());
+EntityRecognizer.dateExp = /^\d{4}-\d{2}-\d{2}/i;
+EntityRecognizer.yesExp = /^(1|y|yes|yep|sure|ok|true)(\W|$)/i;
+EntityRecognizer.noExp = /^(2|n|no|nope|not|false)(\W|$)/i;
+EntityRecognizer.numberExp = /[+-]?(?:\d+\.?\d*|\d*\.?\d+)/;
+EntityRecognizer.ordinalWords = 'first|second|third|fourth|fifth|sixth|seventh|eigth|ninth|tenth';
 exports.EntityRecognizer = EntityRecognizer;

--- a/Node/core/lib/dialogs/PromptRecognizers.js
+++ b/Node/core/lib/dialogs/PromptRecognizers.js
@@ -263,11 +263,11 @@ var PromptRecognizers = (function () {
         if (min === void 0) { min = 0.5; }
         return Math.min(min + (entity.length / utterance.length), max);
     };
-    PromptRecognizers.numOrdinals = {};
-    PromptRecognizers.expCache = {};
-    PromptRecognizers.choiceCache = {};
     return PromptRecognizers;
 }());
+PromptRecognizers.numOrdinals = {};
+PromptRecognizers.expCache = {};
+PromptRecognizers.choiceCache = {};
 exports.PromptRecognizers = PromptRecognizers;
 function matchAll(exp, text) {
     exp.lastIndex = 0;

--- a/Node/core/package.json
+++ b/Node/core/package.json
@@ -2,7 +2,7 @@
   "name": "botbuilder",
   "author": "Microsoft Corp.",
   "description": "Bot Builder is a dialog system for building rich bots on virtually any platform.",
-  "version": "3.10.2",
+  "version": "3.10.5",
   "license": "MIT",
   "keywords": [
     "botbuilder",


### PR DESCRIPTION
This auth change supports the future move from an independent AAD tenant to the Microsoft Services tenant. This will result in new issuer values being sent and returned, primarily from the emulator code paths. As part of this change, the bot builder version numbers were normalized to 3.10.5.