### PR TITLE
Fix bugs in comments in C# SDK samples. 

### DIFF
--- a/CSharp/Samples/AlarmBot/Global.asax.cs
+++ b/CSharp/Samples/AlarmBot/Global.asax.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Bot.Sample.AlarmBot
                 //// Uncomment one of the lines below to choose your store
                 //// var store = new TableBotDataStore("...DataStorageConnectionString..."); // requires Microsoft.BotBuilder.Azure Nuget package 
                 //// var store = new DocumentDbBotDataStore("cosmos db uri", "cosmos db key"); // requires Microsoft.BotBuilder.Azure Nuget package 
-                //// var store = new InMemoryStore(); // volatile in-memory store
+                //// var store = new InMemoryDataStore(); // volatile in-memory store
 
                 //builder.Register(c => store)
                 //    .Keyed<IBotDataStore<BotData>>(AzureModule.Key_DataStore)

--- a/CSharp/Samples/AnnotatedSandwichBot/Global.asax.cs
+++ b/CSharp/Samples/AnnotatedSandwichBot/Global.asax.cs
@@ -20,14 +20,13 @@ namespace Microsoft.Bot.Sample.AnnotatedSandwichBot
             //            // Uncomment one of the lines below to choose your store
             //            // var store = new TableBotDataStore("...DataStorageConnectionString..."); // requires Microsoft.BotBuilder.Azure Nuget package 
             //            // var store = new DocumentDbBotDataStore("cosmos db uri", "cosmos db key"); // requires Microsoft.BotBuilder.Azure Nuget package 
-            //            // var store = new InMemoryStore(); // volatile in-memory store
+            //            // var store = new InMemoryDataStore(); // volatile in-memory store
 
             //            builder.Register(c => store)
             //                .Keyed<IBotDataStore<BotData>>(AzureModule.Key_DataStore)
             //                .AsSelf()
             //                .SingleInstance();
 
-            //            builder.Update(Conversation.Container);
             //        });
 
             GlobalConfiguration.Configure(WebApiConfig.Register);

--- a/CSharp/Samples/EchoBot/Global.asax.cs
+++ b/CSharp/Samples/EchoBot/Global.asax.cs
@@ -20,14 +20,13 @@ namespace Microsoft.Bot.Sample.EchoBot
             //            // Uncomment one of the lines below to choose your store
             //            // var store = new TableBotDataStore("...DataStorageConnectionString..."); // requires Microsoft.BotBuilder.Azure Nuget package 
             //            // var store = new DocumentDbBotDataStore("cosmos db uri", "cosmos db key"); // requires Microsoft.BotBuilder.Azure Nuget package 
-            //            // var store = new InMemoryStore(); // volatile in-memory store
+            //            // var store = new InMemoryDataStore(); // volatile in-memory store
 
             //            builder.Register(c => store)
             //                .Keyed<IBotDataStore<BotData>>(AzureModule.Key_DataStore)
             //                .AsSelf()
             //                .SingleInstance();
 
-            //            builder.Update(Conversation.Container);
             //        });
 
             GlobalConfiguration.Configure(WebApiConfig.Register);

--- a/CSharp/Samples/PizzaBot/Global.asax.cs
+++ b/CSharp/Samples/PizzaBot/Global.asax.cs
@@ -20,14 +20,13 @@ namespace Microsoft.Bot.Sample.PizzaBot
             //            // Uncomment one of the lines below to choose your store
             //            // var store = new TableBotDataStore("...DataStorageConnectionString..."); // requires Microsoft.BotBuilder.Azure Nuget package 
             //            // var store = new DocumentDbBotDataStore("cosmos db uri", "cosmos db key"); // requires Microsoft.BotBuilder.Azure Nuget package 
-            //            // var store = new InMemoryStore(); // volatile in-memory store
+            //            // var store = new InMemoryDataStore(); // volatile in-memory store
 
             //            builder.Register(c => store)
             //                .Keyed<IBotDataStore<BotData>>(AzureModule.Key_DataStore)
             //                .AsSelf()
             //                .SingleInstance();
 
-            //            builder.Update(Conversation.Container);
             //        });
 
             GlobalConfiguration.Configure(WebApiConfig.Register);

--- a/CSharp/Samples/SimpleAlarmBot/Global.asax.cs
+++ b/CSharp/Samples/SimpleAlarmBot/Global.asax.cs
@@ -20,14 +20,13 @@ namespace Microsoft.Bot.Sample.SimpleAlarmBot
             //            // Uncomment one of the lines below to choose your store
             //            // var store = new TableBotDataStore("...DataStorageConnectionString..."); // requires Microsoft.BotBuilder.Azure Nuget package 
             //            // var store = new DocumentDbBotDataStore("cosmos db uri", "cosmos db key"); // requires Microsoft.BotBuilder.Azure Nuget package 
-            //            // var store = new InMemoryStore(); // volatile in-memory store
+            //            // var store = new InMemoryDataStore(); // volatile in-memory store
 
             //            builder.Register(c => store)
             //                .Keyed<IBotDataStore<BotData>>(AzureModule.Key_DataStore)
             //                .AsSelf()
             //                .SingleInstance();
 
-            //            builder.Update(Conversation.Container);
             //        });
 
             GlobalConfiguration.Configure(WebApiConfig.Register);

--- a/CSharp/Samples/SimpleDispatchDialog/Global.asax.cs
+++ b/CSharp/Samples/SimpleDispatchDialog/Global.asax.cs
@@ -20,14 +20,13 @@ namespace Microsoft.Bot.Sample.SimpleDispatchDialog
             //            // Uncomment one of the lines below to choose your store
             //            // var store = new TableBotDataStore("...DataStorageConnectionString..."); // requires Microsoft.BotBuilder.Azure Nuget package 
             //            // var store = new DocumentDbBotDataStore("cosmos db uri", "cosmos db key"); // requires Microsoft.BotBuilder.Azure Nuget package 
-            //            // var store = new InMemoryStore(); // volatile in-memory store
+            //            // var store = new InMemoryDataStore(); // volatile in-memory store
 
             //            builder.Register(c => store)
             //                .Keyed<IBotDataStore<BotData>>(AzureModule.Key_DataStore)
             //                .AsSelf()
             //                .SingleInstance();
 
-            //            builder.Update(Conversation.Container);
             //        });
 
             GlobalConfiguration.Configure(WebApiConfig.Register);

--- a/CSharp/Samples/SimpleEchoBot/Global.asax.cs
+++ b/CSharp/Samples/SimpleEchoBot/Global.asax.cs
@@ -20,14 +20,13 @@ namespace SimpleEchoBot
             //            // Uncomment one of the lines below to choose your store
             //            // var store = new TableBotDataStore("...DataStorageConnectionString..."); // requires Microsoft.BotBuilder.Azure Nuget package 
             //            // var store = new DocumentDbBotDataStore("cosmos db uri", "cosmos db key"); // requires Microsoft.BotBuilder.Azure Nuget package 
-            //            // var store = new InMemoryStore(); // volatile in-memory store
+            //            // var store = new InMemoryDataStore(); // volatile in-memory store
 
             //            builder.Register(c => store)
             //                .Keyed<IBotDataStore<BotData>>(AzureModule.Key_DataStore)
             //                .AsSelf()
             //                .SingleInstance();
 
-            //            builder.Update(Conversation.Container);
             //        });
 
             GlobalConfiguration.Configure(WebApiConfig.Register);

--- a/CSharp/Samples/SimpleFacebookAuthBot/Global.asax.cs
+++ b/CSharp/Samples/SimpleFacebookAuthBot/Global.asax.cs
@@ -20,14 +20,13 @@ namespace Microsoft.Bot.Sample.SimpleFacebookAuthBot
             //            // Uncomment one of the lines below to choose your store
             //            // var store = new TableBotDataStore("...DataStorageConnectionString..."); // requires Microsoft.BotBuilder.Azure Nuget package 
             //            // var store = new DocumentDbBotDataStore("cosmos db uri", "cosmos db key"); // requires Microsoft.BotBuilder.Azure Nuget package 
-            //            // var store = new InMemoryStore(); // volatile in-memory store
+            //            // var store = new InMemoryDataStore(); // volatile in-memory store
 
             //            builder.Register(c => store)
             //                .Keyed<IBotDataStore<BotData>>(AzureModule.Key_DataStore)
             //                .AsSelf()
             //                .SingleInstance();
 
-            //            builder.Update(Conversation.Container);
             //        });
 
             GlobalConfiguration.Configure(WebApiConfig.Register);

--- a/CSharp/Samples/SimpleIVRBot/Global.asax.cs
+++ b/CSharp/Samples/SimpleIVRBot/Global.asax.cs
@@ -20,14 +20,13 @@ namespace SimpleIVRBot
             //            // Uncomment one of the lines below to choose your store
             //            // var store = new TableBotDataStore("...DataStorageConnectionString..."); // requires Microsoft.BotBuilder.Azure Nuget package 
             //            // var store = new DocumentDbBotDataStore("cosmos db uri", "cosmos db key"); // requires Microsoft.BotBuilder.Azure Nuget package 
-            //            // var store = new InMemoryStore(); // volatile in-memory store
+            //            // var store = new InMemoryDataStore(); // volatile in-memory store
 
             //            builder.Register(c => store)
             //                .Keyed<IBotDataStore<BotData>>(AzureModule.Key_DataStore)
             //                .AsSelf()
             //                .SingleInstance();
 
-            //            builder.Update(Conversation.Container);
             //        });
 
 

--- a/CSharp/Samples/SimpleSandwichBot/Global.asax.cs
+++ b/CSharp/Samples/SimpleSandwichBot/Global.asax.cs
@@ -20,14 +20,13 @@ namespace SimpleSandwichBot
             //            // Uncomment one of the lines below to choose your store
             //            // var store = new TableBotDataStore("...DataStorageConnectionString..."); // requires Microsoft.BotBuilder.Azure Nuget package 
             //            // var store = new DocumentDbBotDataStore("cosmos db uri", "cosmos db key"); // requires Microsoft.BotBuilder.Azure Nuget package 
-            //            // var store = new InMemoryStore(); // volatile in-memory store
+            //            // var store = new InMemoryDataStore(); // volatile in-memory store
 
             //            builder.Register(c => store)
             //                .Keyed<IBotDataStore<BotData>>(AzureModule.Key_DataStore)
             //                .AsSelf()
             //                .SingleInstance();
 
-            //            builder.Update(Conversation.Container);
             //        });
 
             GlobalConfiguration.Configure(WebApiConfig.Register);

--- a/CSharp/Samples/TemplateBot/Global.asax.cs
+++ b/CSharp/Samples/TemplateBot/Global.asax.cs
@@ -19,14 +19,13 @@ namespace Microsoft.Bot.Sample.TemplateBot
             //            // Uncomment one of the lines below to choose your store
             //            // var store = new TableBotDataStore("...DataStorageConnectionString..."); // requires Microsoft.BotBuilder.Azure Nuget package 
             //            // var store = new DocumentDbBotDataStore("cosmos db uri", "cosmos db key"); // requires Microsoft.BotBuilder.Azure Nuget package 
-            //            // var store = new InMemoryStore(); // volatile in-memory store
+            //            // var store = new InMemoryDataStore(); // volatile in-memory store
 
             //            builder.Register(c => store)
             //                .Keyed<IBotDataStore<BotData>>(AzureModule.Key_DataStore)
             //                .AsSelf()
             //                .SingleInstance();
 
-            //            builder.Update(Conversation.Container);
             //        });
 
             GlobalConfiguration.Configure(WebApiConfig.Register);


### PR DESCRIPTION
InMemoryDataStore name was incorrect, and also there was a mix in autofact patterns for the samples that used Conversation.UpdateContainer().