### PR TITLE
Support ASP.Net Core 2.0 to Microsoft.Bot.Builder

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder.Autofac/Microsoft.Bot.Builder.Autofac.csproj
+++ b/CSharp/Library/Microsoft.Bot.Builder.Autofac/Microsoft.Bot.Builder.Autofac.csproj
@@ -1,54 +1,17 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{2C145824-38DD-409C-AB52-B3538997726C}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <RootNamespace>Microsoft.Bot.Builder.Autofac</RootNamespace>
     <AssemblyName>Microsoft.Bot.Builder.Autofac</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <Version>3.10.1</Version>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <NoWarn>CS1998;CS1591;CS0419</NoWarn>
-    <DocumentationFile>bin\Debug\Microsoft.Bot.Builder.Autofac.XML</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <NoWarn>CS1998;CS1591;CS0419</NoWarn>
-    <DocumentationFile>bin\Release\Microsoft.Bot.Builder.Autofac.XML</DocumentationFile>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Rest.ClientRuntime.2.3.2\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -64,12 +27,17 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Autofac" Version="4.6.1" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="Base\Extensions.cs" />
     <Compile Include="Dialogs\Conversation.cs" />
     <Compile Include="Dialogs\DialogModule.cs" />
     <Compile Include="Fibers\DoNotSerializeResolver.cs" />
     <Compile Include="Fibers\FiberModule.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Scorables\Resolver.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -79,21 +47,9 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Bot.Builder\Microsoft.Bot.Builder.csproj">
-      <Project>{cdfec7d6-847e-4c13-956b-0a960ae3eb60}</Project>
-      <Name>Microsoft.Bot.Builder</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.Bot.Connector.NetFramework\Microsoft.Bot.Connector.csproj">
-      <Project>{df397efc-91db-4911-9971-c509926fc288}</Project>
-      <Name>Microsoft.Bot.Connector</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.Bot.Builder\Microsoft.Bot.Builder.csproj" />
+    <ProjectReference Include="..\Microsoft.Bot.Connector.NetCore\Microsoft.Bot.Connector.NetCore.csproj" />
+    <ProjectReference Include="..\Microsoft.Bot.Connector.AspNetCore\Microsoft.Bot.Connector.AspNetCore.csproj" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/BotData.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/BotData.cs
@@ -140,7 +140,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
         {
             if (botData.ETag != "*" && Deserialize(value).ETag != botData.ETag)
             {
+#if NET45
                 throw new HttpException((int)HttpStatusCode.PreconditionFailed, "Inconsistent SaveAsync based on ETag!");
+#else
+                throw new HttpListenerException((int)HttpStatusCode.PreconditionFailed, "Inconsistent SaveAsync based on ETag!");
+#endif
             }
         }
 

--- a/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/UrlToken.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/UrlToken.cs
@@ -70,7 +70,11 @@ namespace Microsoft.Bot.Builder.Dialogs
                     var serializer = JsonSerializer.CreateDefault();
                     serializer.Serialize(writer, item);
                 }
+#if NET45
                 var token = HttpServerUtility.UrlTokenEncode(memory.ToArray());
+#else
+                var token = HttpUtility.UrlEncode(memory.ToArray());
+#endif
                 return token;
             }
         }
@@ -83,7 +87,11 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <returns>The item instance.</returns>
         public static T Decode<T>(string token)
         {
+#if NET45
             var buffer = HttpServerUtility.UrlTokenDecode(token);
+#else
+            var buffer = Encoding.UTF8.GetBytes(HttpUtility.UrlDecode(token));
+#endif
             using (var memory = new MemoryStream(buffer))
             using (var gzip = new GZipStream(memory, CompressionMode.Decompress))
             using (var reader = new BsonReader(gzip))

--- a/CSharp/Library/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
+++ b/CSharp/Library/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
@@ -1,58 +1,38 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{CDFEC7D6-847E-4C13-956B-0A960AE3EB60}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <RootNamespace>Microsoft.Bot.Builder</RootNamespace>
     <AssemblyName>Microsoft.Bot.Builder</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <Version>3.11.0</Version>
     <NoWarn>CS1998;CS1591;CS0419</NoWarn>
-    <DocumentationFile>bin\Debug\Microsoft.Bot.Builder.XML</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <NoWarn>CS1998;CS1591;CS0419</NoWarn>
-    <DocumentationFile>bin\Release\Microsoft.Bot.Builder.XML</DocumentationFile>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <IsPackable>true</IsPackable>
+    <NuspecFile>Microsoft.Bot.Builder.nuspec</NuspecFile>
+    <PackageOutputPath>..\nuget</PackageOutputPath>
+    <NuspecProperties>version=$(Version)</NuspecProperties>
   </PropertyGroup>
   <PropertyGroup Label="MultilingualAppToolkit">
     <MultilingualAppToolkitVersion>4.0</MultilingualAppToolkitVersion>
     <MultilingualFallbackLanguage>en</MultilingualFallbackLanguage>
   </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <DefineConstants>$(DefineConstants);NET45</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="Chronic, Version=0.3.2.0, Culture=neutral, PublicKeyToken=3bd1f1ef638b0d3c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Chronic.Signed.0.3.2\lib\net40\Chronic.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Rest.ClientRuntime.2.3.2\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <PackageReference Include="re-Chronic" Version="0.3.2" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="NuGet.CommandLine" Version="4.1.0" DevelopmentDependency="true" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -67,6 +47,11 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Bot.Connector.NetCore\Microsoft.Bot.Connector.NetCore.csproj" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="Base\EventLoop.cs" />
     <Compile Include="Base\Extensions.cs" />
@@ -159,7 +144,6 @@
     <Compile Include="Luis\Models\EntityRecommendation.cs" />
     <Compile Include="Luis\Models\IntentRecommendation.cs" />
     <Compile Include="Luis\Models\LuisResult.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resource\Extensions.cs" />
     <Compile Include="Resource\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -239,21 +223,7 @@
     <XliffResource Include="MultilingualResources\Microsoft.Bot.Builder.zh-Hans.xlf" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Bot.Connector.NetFramework\Microsoft.Bot.Connector.csproj">
-      <Project>{df397efc-91db-4911-9971-c509926fc288}</Project>
-      <Name>Microsoft.Bot.Connector</Name>
-    </ProjectReference>
+    <DotNetCliToolReference Include="NuGet.CommandLine" Version="4.1.0" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets" Label="MultilingualAppToolkit" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets') And Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\v$(MultilingualAppToolkitVersion)\Microsoft.Multilingual.ResxResources.targets')" />
-  <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets') And !Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\v$(MultilingualAppToolkitVersion)\Microsoft.Multilingual.ResxResources.targets')" Label="MultilingualAppToolkit">
-    <Warning Text="$(MSBuildProjectFile) is Multilingual build enabled, but the Multilingual App Toolkit is unavailable during the build. If building with Visual Studio, please check to ensure that toolkit is properly installed." />
-  </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/CSharp/Library/Microsoft.Bot.Builder/Microsoft.Bot.Builder.nuspec
+++ b/CSharp/Library/Microsoft.Bot.Builder/Microsoft.Bot.Builder.nuspec
@@ -22,25 +22,59 @@
     <summary>Microsoft.Bot.Builder is a framework for easily building stateless bots that span from regular expressions to AI based natural language.</summary>
     <language>en-US</language>
     <dependencies>
-      <dependency id="Autofac" version="3.5.2"/>
-      <dependency id="Chronic.Signed" version="0.3.2" />
-      <dependency id="Microsoft.AspNet.WebAPI.Core" version="5.2.3" />
-      <dependency id="Microsoft.Bot.Connector" version="3.11.0" />
-      <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.2" />
-      <dependency id="Newtonsoft.Json" version="8.0.3" />
-      <dependency id="System.IdentityModel.Tokens.Jwt" version="[4.0.4.403061554,5.0)" />
-      <dependency id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.4.403061554" />
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Autofac" version="4.6.1"/>
+        <dependency id="Microsoft.AspNet.WebAPI.Core" version="5.2.3" />
+        <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
+        <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />
+        <dependency id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.4.403061554" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="2.1.4" />
+        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.10" />
+        <dependency id="Newtonsoft.Json" version="10.0.3" />
+        <dependency id="re-Chronic" version="0.3.2" />
+        <dependency id="System.IdentityModel.Tokens.Jwt" version="5.1.4" />
+      </group>
+      <group targetFramework=".NETFramework4.6">
+        <dependency id="Autofac" version="4.6.1"/>
+        <dependency id="Microsoft.AspNet.WebApi.Client" version="5.2.3" />
+        <dependency id="Microsoft.AspNet.WebAPI.Core" version="5.2.3" />
+        <dependency id="Microsoft.IdentityModel.Protocol.Extensions" version="[1.0.4.403061554]" />
+        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.10" />
+        <dependency id="Newtonsoft.Json" version="10.0.3" />
+        <dependency id="re-Chronic" version="0.3.2" />
+        <dependency id="System.IdentityModel.Tokens.Jwt" version="[4.0.4.403061554,5.0)" />
+      </group>
     </dependencies>
   </metadata>
   <files>
+    <!-- assembly Microsoft.Bot.Connector -->
+    <file src="..\Microsoft.Bot.Connector.NetCore\bin\release\net46\Microsoft.Bot.Connector.NetCore.dll" target="lib\net46"/>
+    <file src="..\Microsoft.Bot.Connector.NetCore\bin\release\net46\Microsoft.Bot.Connector.NetCore.xml" target="lib\net46" />
+    <file src="..\Microsoft.Bot.Connector.NetCore\bin\release\net46\Microsoft.Bot.Connector.NetCore.pdb" target="lib\net46" />
+    <file src="..\Microsoft.Bot.Connector.NetCore\bin\release\netstandard2.0\Microsoft.Bot.Connector.NetCore.dll" target="lib\netstandard2.0"/>
+    <file src="..\Microsoft.Bot.Connector.NetCore\bin\release\netstandard2.0\Microsoft.Bot.Connector.NetCore.xml" target="lib\netstandard2.0" />
+    <file src="..\Microsoft.Bot.Connector.NetCore\bin\release\netstandard2.0\Microsoft.Bot.Connector.NetCore.pdb" target="lib\netstandard2.0" />
+    <!-- assembly Microsoft.Bot.Connector.AspNetCore -->
+    <file src="..\Microsoft.Bot.Connector.AspNetCore\bin\release\net46\Microsoft.Bot.Connector.dll" target="lib\net46"/>
+    <file src="..\Microsoft.Bot.Connector.AspNetCore\bin\release\net46\Microsoft.Bot.Connector.xml" target="lib\net46" />
+    <file src="..\Microsoft.Bot.Connector.AspNetCore\bin\release\net46\Microsoft.Bot.Connector.pdb" target="lib\net46" />
+    <file src="..\Microsoft.Bot.Connector.AspNetCore\bin\release\netstandard2.0\Microsoft.Bot.Connector.dll" target="lib\netstandard2.0"/>
+    <file src="..\Microsoft.Bot.Connector.AspNetCore\bin\release\netstandard2.0\Microsoft.Bot.Connector.xml" target="lib\netstandard2.0" />
+    <file src="..\Microsoft.Bot.Connector.AspNetCore\bin\release\netstandard2.0\Microsoft.Bot.Connector.pdb" target="lib\netstandard2.0" />
     <!-- assembly Microsoft.Bot.Builder -->
-    <file src="..\Microsoft.Bot.Builder\bin\release\Microsoft.Bot.Builder.dll" target="lib\net46"/>
-    <file src="..\Microsoft.Bot.Builder\bin\release\Microsoft.Bot.Builder.xml" target="lib\net46" />
-    <file src="..\Microsoft.Bot.Builder\bin\release\Microsoft.Bot.Builder.pdb" target="lib\net46" />
+    <file src="..\Microsoft.Bot.Builder\bin\release\net46\Microsoft.Bot.Builder.dll" target="lib\net46" />
+    <file src="..\Microsoft.Bot.Builder\bin\release\net46\Microsoft.Bot.Builder.xml" target="lib\net46" />
+    <file src="..\Microsoft.Bot.Builder\bin\release\net46\Microsoft.Bot.Builder.pdb" target="lib\net46" />
+    <file src="..\Microsoft.Bot.Builder\bin\release\netstandard2.0\Microsoft.Bot.Builder.dll" target="lib\netstandard2.0" />
+    <file src="..\Microsoft.Bot.Builder\bin\release\netstandard2.0\Microsoft.Bot.Builder.xml" target="lib\netstandard2.0" />
+    <file src="..\Microsoft.Bot.Builder\bin\release\netstandard2.0\Microsoft.Bot.Builder.pdb" target="lib\netstandard2.0" />
     <!-- assembly Microsoft.Bot.Builder.Autofac -->
-    <file src="..\Microsoft.Bot.Builder.Autofac\bin\release\Microsoft.Bot.Builder.Autofac.dll"  target="lib\net46" />
-    <file src="..\Microsoft.Bot.Builder.Autofac\bin\release\Microsoft.Bot.Builder.Autofac.xml"  target="lib\net46" />
-    <file src="..\Microsoft.Bot.Builder.Autofac\bin\release\Microsoft.Bot.Builder.Autofac.pdb"  target="lib\net46" />
+    <file src="..\Microsoft.Bot.Builder.Autofac\bin\release\net46\Microsoft.Bot.Builder.Autofac.dll"  target="lib\net46" />
+    <file src="..\Microsoft.Bot.Builder.Autofac\bin\release\net46\Microsoft.Bot.Builder.Autofac.xml"  target="lib\net46" />
+    <file src="..\Microsoft.Bot.Builder.Autofac\bin\release\net46\Microsoft.Bot.Builder.Autofac.pdb"  target="lib\net46" />
+    <file src="..\Microsoft.Bot.Builder.Autofac\bin\release\netstandard2.0\Microsoft.Bot.Builder.Autofac.dll"  target="lib\netstandard2.0" />
+    <file src="..\Microsoft.Bot.Builder.Autofac\bin\release\netstandard2.0\Microsoft.Bot.Builder.Autofac.xml"  target="lib\netstandard2.0" />
+    <file src="..\Microsoft.Bot.Builder.Autofac\bin\release\netstandard2.0\Microsoft.Bot.Builder.Autofac.pdb"  target="lib\netstandard2.0" />
     <!-- source -->
     <file src="..\**\*.cs"
           exclude="**\obj\**\*.cs;..\Microsoft.Bot.Builder.Azure\**;..\Microsoft.Bot.Builder.Calling\**;..\Microsoft.Bot.Builder.FormFlow.Json\**;..\Microsoft.Bot.Builder.History\**;..\Microsoft.Bot.Connector.AspNetCore\**;..\Microsoft.Bot.Connector.NetCore\**"
@@ -48,18 +82,31 @@
     <!-- tools -->
     <file src="..\..\tools\rview\bin\release\RView.exe" target="tools"/>
     <!-- resources -->
-    <file src="bin\release\ar\*.dll" target="lib\net46\ar"/>
-    <file src="bin\release\cs\*.dll" target="lib\net46\cs"/>
-    <file src="bin\release\de-dE\*.dll" target="lib\net46\de-dE"/>
-    <file src="bin\release\pt-BR\*.dll" target="lib\net46\pt-BR"/>
-    <file src="bin\release\en\*.dll" target="lib\net46\en"/>
-    <file src="bin\release\es\*.dll" target="lib\net46\es"/>
-    <file src="bin\release\fa\*.dll" target="lib\net46\fa"/>
-    <file src="bin\release\fr\*.dll" target="lib\net46\fr"/>
-    <file src="bin\release\it\*.dll" target="lib\net46\it"/>
-    <file src="bin\release\ja\*.dll" target="lib\net46\ja"/>
-    <file src="bin\release\nl\*.dll" target="lib\net46\nl"/>
-    <file src="bin\release\ru\*.dll" target="lib\net46\ru"/>
-    <file src="bin\release\zh-hans\*.dll" target="lib\net46\zh-hans"/>
+    <file src="bin\release\net46\ar\*.dll" target="lib\net46\ar"/>
+    <file src="bin\release\net46\cs\*.dll" target="lib\net46\cs"/>
+    <file src="bin\release\net46\de-dE\*.dll" target="lib\net46\de-dE"/>
+    <file src="bin\release\net46\pt-BR\*.dll" target="lib\net46\pt-BR"/>
+    <file src="bin\release\net46\en\*.dll" target="lib\net46\en"/>
+    <file src="bin\release\net46\es\*.dll" target="lib\net46\es"/>
+    <file src="bin\release\net46\fa\*.dll" target="lib\net46\fa"/>
+    <file src="bin\release\net46\fr\*.dll" target="lib\net46\fr"/>
+    <file src="bin\release\net46\it\*.dll" target="lib\net46\it"/>
+    <file src="bin\release\net46\ja\*.dll" target="lib\net46\ja"/>
+    <file src="bin\release\net46\nl\*.dll" target="lib\net46\nl"/>
+    <file src="bin\release\net46\ru\*.dll" target="lib\net46\ru"/>
+    <file src="bin\release\net46\zh-hans\*.dll" target="lib\net46\zh-hans"/>
+    <file src="bin\release\netstandard2.0\ar\*.dll" target="lib\netstandard2.0\ar"/>
+    <file src="bin\release\netstandard2.0\cs\*.dll" target="lib\netstandard2.0\cs"/>
+    <file src="bin\release\netstandard2.0\de-dE\*.dll" target="lib\netstandard2.0\de-dE"/>
+    <file src="bin\release\netstandard2.0\pt-BR\*.dll" target="lib\netstandard2.0\pt-BR"/>
+    <file src="bin\release\netstandard2.0\en\*.dll" target="lib\netstandard2.0\en"/>
+    <file src="bin\release\netstandard2.0\es\*.dll" target="lib\netstandard2.0\es"/>
+    <file src="bin\release\netstandard2.0\fa\*.dll" target="lib\netstandard2.0\fa"/>
+    <file src="bin\release\netstandard2.0\fr\*.dll" target="lib\netstandard2.0\fr"/>
+    <file src="bin\release\netstandard2.0\it\*.dll" target="lib\netstandard2.0\it"/>
+    <file src="bin\release\netstandard2.0\ja\*.dll" target="lib\netstandard2.0\ja"/>
+    <file src="bin\release\netstandard2.0\nl\*.dll" target="lib\netstandard2.0\nl"/>
+    <file src="bin\release\netstandard2.0\ru\*.dll" target="lib\netstandard2.0\ru"/>
+    <file src="bin\release\netstandard2.0\zh-hans\*.dll" target="lib\netstandard2.0\zh-hans"/>
   </files>
 </package>

--- a/CSharp/Library/Microsoft.Bot.Builder/createpackage.cmd
+++ b/CSharp/Library/Microsoft.Bot.Builder/createpackage.cmd
@@ -7,11 +7,19 @@ set errorlevel=0
 mkdir ..\nuget
 erase /s ..\nuget\Microsoft.Bot.Connector*.nupkg
 erase /s ..\nuget\Microsoft.Bot.Builder*.nupkg
-msbuild /property:Configuration=release /p:DefineConstants="NET45" ..\Microsoft.Bot.Connector.NetFramework\Microsoft.Bot.Connector.csproj 
-msbuild /property:Configuration=release ..\Microsoft.Bot.Builder.Autofac\Microsoft.Bot.Builder.Autofac.csproj 
-msbuild /property:Configuration=release Microsoft.Bot.Builder.csproj 
+rem msbuild /property:Configuration=release /p:DefineConstants="NET45" ..\Microsoft.Bot.Connector.NetFramework\Microsoft.Bot.Connector.csproj 
+dotnet restore ..\Microsoft.Bot.Connector.NetCore\Microsoft.Bot.Connector.NetCore.csproj
+dotnet build -c Release ..\Microsoft.Bot.Connector.NetCore\Microsoft.Bot.Connector.NetCore.csproj
+dotnet restore ..\Microsoft.Bot.Connector.AspNetCore\Microsoft.Bot.Connector.AspNetCore.csproj
+dotnet build -c Release ..\Microsoft.Bot.Connector.AspNetCore\Microsoft.Bot.Connector.AspNetCore.csproj
+rem msbuild /property:Configuration=release ..\Microsoft.Bot.Builder.Autofac\Microsoft.Bot.Builder.Autofac.csproj 
+dotnet restore ..\Microsoft.Bot.Builder.Autofac\Microsoft.Bot.Builder.Autofac.csproj
+dotnet build -c Release ..\Microsoft.Bot.Builder.Autofac\Microsoft.Bot.Builder.Autofac.csproj
+rem msbuild /property:Configuration=release Microsoft.Bot.Builder.csproj 
+dotnet restore Microsoft.Bot.Builder.csproj
+dotnet build -c Release Microsoft.Bot.Builder.csproj
 msbuild /property:Configuration=release ..\..\tools\rview\rview.csproj
-for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\Microsoft.Bot.Builder.dll).FileVersionInfo.FileVersion"') do set version=%%v
-..\..\packages\NuGet.CommandLine.4.1.0\tools\NuGet.exe pack Microsoft.Bot.Builder.nuspec -symbols -properties version=%version% -OutputDirectory ..\nuget
+for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\net46\Microsoft.Bot.Builder.dll).FileVersionInfo.FileVersion"') do set version=%%v
+rem ..\..\packages\NuGet.CommandLine.4.1.0\tools\NuGet.exe pack Microsoft.Bot.Builder.nuspec -symbols -properties version=%version% -OutputDirectory ..\nuget
+dotnet pack -c Release --no-build --include-symbols
 echo *** Finished building Microsoft.Bot.Builder
-

--- a/CSharp/Library/Microsoft.Bot.Connector.AspNetCore/BotAuthentication2.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.AspNetCore/BotAuthentication2.cs
@@ -1,0 +1,223 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Connector
+{
+    /// <summary>
+    /// Bot authenticate for RECEIVED Activity
+    /// </summary>
+    /// <example>
+    /// [BotAuthentication]
+    /// [HttpPost]
+    /// public async Task Post([FromBody]Activity activity)
+    /// </example>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    public class BotAuthentication : AuthorizeAttribute, IActionFilter
+    {
+        public BotAuthentication()
+        {
+            AuthenticationSchemes = BotAuthenticationAppBuilderExtensions.DefaultBotAuthenticationScheme;
+        }
+
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+        }
+
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+            var activities = GetActivities(context);
+
+            foreach (var activity in activities)
+            {
+                MicrosoftAppCredentials.TrustServiceUrl(activity.ServiceUrl);
+            }
+        }
+
+        public static IList<Activity> GetActivities(ActionExecutingContext actionContext)
+        {
+            var activties = actionContext.ActionArguments.Select(t => t.Value).OfType<Activity>().ToList();
+            if (activties.Any())
+            {
+                return activties;
+            }
+            else
+            {
+                var objects =
+                    actionContext.ActionArguments.Where(t => t.Value is JObject || t.Value is JArray)
+                        .Select(t => t.Value).ToArray();
+                if (objects.Any())
+                {
+                    activties = new List<Activity>();
+                    foreach (var obj in objects)
+                    {
+                        activties.AddRange((obj is JObject) ? new Activity[] { ((JObject)obj).ToObject<Activity>() } : ((JArray)obj).ToObject<Activity[]>());
+                    }
+                }
+            }
+            return activties;
+        }
+    }
+
+    /// <summary>
+    /// Extension methods to add BotAuthentication capabilities to an HTTP service collection.
+    /// </summary>
+    /// <example>
+    /// public void ConfigureServices(IServiceCollection services)
+    /// {
+    ///     services.AddAuthentication().AddBot("{AppId}", "{AppPassword}");
+    /// }
+    /// </example>
+    public static class BotAuthenticationAppBuilderExtensions
+    {
+        public const string DefaultBotAuthenticationScheme = "Bot";
+        public const string BotClaim = "Bot";
+
+        public static AuthenticationBuilder AddBot(this AuthenticationBuilder authBuilder, string microsoftAppId = null, string microsoftAppPassword = null)
+        {
+            if (String.IsNullOrWhiteSpace(microsoftAppId))
+            {
+                microsoftAppId = Environment.GetEnvironmentVariable(MicrosoftAppCredentials.MicrosoftAppIdKey, EnvironmentVariableTarget.Process);
+            }
+            if (String.IsNullOrWhiteSpace(microsoftAppPassword))
+            {
+                microsoftAppPassword = Environment.GetEnvironmentVariable(MicrosoftAppCredentials.MicrosoftAppPasswordKey, EnvironmentVariableTarget.Process);
+            }
+
+            return authBuilder.AddBot(new StaticCredentialProvider(microsoftAppId, microsoftAppPassword));
+        }
+
+        public static AuthenticationBuilder AddBot(this AuthenticationBuilder authBuilder, ICredentialProvider credentialProvider)
+        {
+            return authBuilder.AddBot(new BotAuthenticationOptions(credentialProvider));
+        }
+
+        public static AuthenticationBuilder AddBot(this AuthenticationBuilder authBuilder, BotAuthenticationOptions options)
+        {
+            authBuilder.Services.AddSingleton(typeof(BotAuthenticationOptions), options);
+            var ret = authBuilder.AddScheme<BotAuthenticationOptions, BotAuthenticationHandler>(BotAuthenticationAppBuilderExtensions.DefaultBotAuthenticationScheme, (conf) =>
+            {
+                conf.CredentialProvider = options.CredentialProvider;
+                conf.OpenIdConfiguration = options.OpenIdConfiguration;
+                conf.DisableEmulatorTokens = options.DisableEmulatorTokens;
+                conf.SaveToken = options.SaveToken;
+            });
+            return ret;
+        }
+    }
+
+    /// <summary>
+    /// Uses Authentication for Bot Connector
+    /// </summary>
+    public interface IBotAuthenticationOptions
+    {
+        ICredentialProvider CredentialProvider { set; get; }
+        string OpenIdConfiguration { set; get; }
+        bool DisableEmulatorTokens { set; get; }
+        bool SaveToken { set; get; }
+    }
+
+    /// <summary>
+    /// implementation to Authentication for Bot Connector
+    /// </summary>
+    public class BotAuthenticationOptions : AuthenticationSchemeOptions, IBotAuthenticationOptions
+    {
+        public BotAuthenticationOptions()
+        {
+        }
+
+        public BotAuthenticationOptions(ICredentialProvider credentialProvider)
+        {
+            CredentialProvider = credentialProvider;
+        }
+
+        /// <summary>
+        /// The <see cref="ICredentialProvider"/> used for authentication.
+        /// </summary>
+        public ICredentialProvider CredentialProvider { set; get; }
+
+        /// <summary>
+        /// The OpenId configuation.
+        /// </summary>
+        public string OpenIdConfiguration { set; get; } = JwtConfig.ToBotFromChannelOpenIdMetadataUrl;
+
+        /// <summary>
+        /// Flag indicating if emulator tokens should be disabled.
+        /// </summary>
+        public bool DisableEmulatorTokens { set; get; } = false;
+
+        /// <summary>
+        /// Flag indicating if <see cref="BotAuthenticationHandler"/> should be stored in 
+        /// the returned <see cref="Microsoft.AspNetCore.Authentication.AuthenticationTicket"/>. 
+        /// </summary>
+        public bool SaveToken { set; get; } = true;
+    }
+
+    /// <summary>
+    /// Authentication Handler
+    /// </summary>
+    public class BotAuthenticationHandler : AuthenticationHandler<BotAuthenticationOptions>
+    {
+        public BotAuthenticationHandler(IOptionsMonitor<BotAuthenticationOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock) : base(options, logger, encoder, clock)
+        {
+        }
+
+        protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (await Options.CredentialProvider.IsAuthenticationDisabledAsync())
+            {
+                var principal = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim(ClaimTypes.Role, BotAuthenticationAppBuilderExtensions.BotClaim) }));
+                return AuthenticateResult.Success(new AuthenticationTicket(principal, new AuthenticationProperties(), JwtBearerDefaults.AuthenticationScheme));
+            }
+
+            string token = null;
+
+            string authorization = Request.Headers["Authorization"];
+            token = authorization?.Substring("Bearer ".Length).Trim();
+
+            // If no token found, no further work possible
+            // and Authentication is not disabled fail
+            if (string.IsNullOrEmpty(token))
+            {
+                return AuthenticateResult.Fail("No JwtToken is present and BotAuthentication is enabled!");
+            }
+
+            var authenticator = new BotAuthenticator(Options.CredentialProvider, Options.OpenIdConfiguration, Options.DisableEmulatorTokens);
+            var identityToken = await authenticator.TryAuthenticateAsync(JwtBearerDefaults.AuthenticationScheme, token, CancellationToken.None);
+
+            if (identityToken.Authenticated)
+            {
+                identityToken.Identity.AddClaim(new Claim(ClaimTypes.Role, BotAuthenticationAppBuilderExtensions.BotClaim));
+                var principal = new ClaimsPrincipal(identityToken.Identity);
+                var ticket = new AuthenticationTicket(principal, new AuthenticationProperties(), JwtBearerDefaults.AuthenticationScheme);
+                Context.User = principal;
+
+                if (Options.SaveToken)
+                {
+                    ticket.Properties.StoreTokens(new[]
+                            {
+                                new AuthenticationToken { Name = "access_token", Value = token }
+                            });
+                }
+
+                return AuthenticateResult.Success(ticket);
+            }
+            else
+            {
+                return AuthenticateResult.Fail($"Failed to authenticate JwtToken {token}");
+            }
+        }
+    }
+}

--- a/CSharp/Library/Microsoft.Bot.Connector.AspNetCore/Microsoft.Bot.Connector.AspNetCore.csproj
+++ b/CSharp/Library/Microsoft.Bot.Connector.AspNetCore/Microsoft.Bot.Connector.AspNetCore.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <AssemblyTitle>Microsoft.Bot.Connector</AssemblyTitle>
+    <Version>3.11.1</Version>
     <VersionPrefix>3.8.0</VersionPrefix>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard1.6;net46</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Microsoft.Bot.Connector</AssemblyName>
     <PackageId>Microsoft.Bot.Connector.AspNetCore</PackageId>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -18,16 +18,63 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <AssemblyVersion>3.11.1.0</AssemblyVersion>
     <FileVersion>3.11.1.0</FileVersion>
+
+    <IsPackable>true</IsPackable>
+    <NuspecFile>..\Microsoft.Bot.Connector.NetFramework\Microsoft.Bot.Connector.nuspec</NuspecFile>
+    <PackageOutputPath>..\nuget</PackageOutputPath>
+    <NuspecProperties>version=$(Version)</NuspecProperties>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Bot.Connector.NetCore\Microsoft.Bot.Connector.NetCore.csproj" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.4" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[1.1.3]" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="[5.1.4]" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[1.1.4]" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="2.1.4" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[1.1.3]" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="[5.1.4]" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[1.1.4]" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+
+    <PackageReference Include="Microsoft.IdentityModel.Protocol.Extensions" Version="[1.0.4.403061554]" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="[5.2.3]" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="[5.2.3]" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <Compile Include="BotAuthentication2.cs" Exclude="**/AssemblyInfo.cs;**/*.AssemblyInfo.cs;BotAuthentication.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+    <Compile Include="**/*.cs" Exclude="BotAuthentication2.cs;**/AssemblyInfo.cs;**/*.AssemblyInfo.cs;BotAuthentication.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <Content Include="bin\$(Configuration)\netstandard2.0\Microsoft.Bot.Connector.xml" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <Content Include="bin\$(Configuration)\netstandard1.6\Microsoft.Bot.Connector.xml" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Content Include="bin\$(Configuration)\net46\Microsoft.Bot.Connector.xml" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="1.0.2" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.0.3" />
+    <ProjectReference Include="..\Microsoft.Bot.Connector.NetCore\Microsoft.Bot.Connector.NetCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/CSharp/Library/Microsoft.Bot.Connector.NetCore/Microsoft.Bot.Connector.NetCore.csproj
+++ b/CSharp/Library/Microsoft.Bot.Connector.NetCore/Microsoft.Bot.Connector.NetCore.csproj
@@ -1,59 +1,134 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{992F6A37-10D0-4676-A18E-8343A1F09FFF}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Microsoft.Bot.Connector</RootNamespace>
+    <TargetFrameworks>netstandard2.0;netstandard1.6;net46;net45</TargetFrameworks>
+    <RootNamespace>Microsoft.Bot.Connector.NetCore</RootNamespace>
     <AssemblyName>Microsoft.Bot.Connector.NetCore</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
-    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateDocumentation>true</GenerateDocumentation>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.Bot.Connector.NetCore.xml</DocumentationFile>
+    <Version>3.11.1</Version>
+    <NoWarn>CS1998;CS1591;CS0419</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>Content\Microsoft.Bot.Connector.NetCore.XML</DocumentationFile>
-    <NoWarn>CS1591</NoWarn>
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <NuspecFile>..\Microsoft.Bot.Connector.NetFramework\Microsoft.Bot.Connector.nuspec</NuspecFile>
+    <PackageVersion>$(version)-alpha</PackageVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <RootNamespace>Microsoft.Bot.Connector</RootNamespace>
+    <AssemblyName>Microsoft.Bot.Connector</AssemblyName>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.Bot.Connector.xml</DocumentationFile>
   </PropertyGroup>
-  <ItemGroup>
-    <!-- A reference to the entire .NET Framework is automatically included -->
-    <None Include="project.json" />
-    <None Include="project.lock.json" />
+  <PropertyGroup Condition=" ( '$(TargetFramework)' == 'net45' ) OR ( '$(TargetFramework)' == 'net46' ) ">
+    <DefineConstants>$(DefineConstants);NET45</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="2.1.4" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.4" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="2.1.4" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.4" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="Content\Microsoft.Bot.Connector.NetCore.XML" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.3" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.3" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocol.Extensions" Version="[1.0.4.403061554]" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="[5.2.3]" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="[5.2.3]" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocol.Extensions" Version="[1.0.4.403061554]" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="[2.3.2]" />
+    <PackageReference Include="Newtonsoft.Json" Version="[8.0.3]" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net461\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition=" ( '$(TargetFramework)' == 'net45' ) OR ( '$(TargetFramework)' == 'net46' ) ">
+    <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.40306.1554, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.4.403061554\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Rest.ClientRuntime.2.3.2\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.40306.1554, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.4.0.4.403061554\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <Compile Include="**/*.cs" Exclude="**/AssemblyInfo.cs;**/*.AssemblyInfo.cs;BotAuthentication.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <Compile Include="**/*.cs" Exclude="**/AssemblyInfo.cs;**/*.AssemblyInfo.cs;BotAuthentication.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" ( '$(TargetFramework)' == 'net45' ) OR ( '$(TargetFramework)' == 'net46' ) ">
+    <Compile Include="..\Microsoft.Bot.Connector.NetFramework\BotAuthentication.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <Content Include="bin\$(Configuration)\netstandard2.0\Microsoft.Bot.Connector.NetCore.xml" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <Content Include="bin\$(Configuration)\netstandard1.6\Microsoft.Bot.Connector.NetCore.xml" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Content Include="bin\$(Configuration)\net46\Microsoft.Bot.Connector.NetCore.xml" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <Content Include="bin\$(Configuration)\net45\Microsoft.Bot.Connector.xml" />
+  </ItemGroup>
+
   <Import Project="..\Microsoft.Bot.Connector.Shared\Microsoft.Bot.Connector.Shared.projitems" Label="Shared" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/CSharp/Library/Microsoft.Bot.Connector.NetFramework/Microsoft.Bot.Connector.nuspec
+++ b/CSharp/Library/Microsoft.Bot.Connector.NetFramework/Microsoft.Bot.Connector.nuspec
@@ -11,24 +11,44 @@
     <language>en-US</language>
     <dependencies>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="Microsoft.AspNet.WebApi.Client" version="5.2.3" />
-        <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2.3" />
-        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.2" />
-        <dependency id="Newtonsoft.Json" version="8.0.3" />
+        <dependency id="Microsoft.AspNet.WebApi.Client" version="[5.2.3]" />
+        <dependency id="Microsoft.AspNet.WebApi.Core" version="[5.2.3]" />
+        <dependency id="Microsoft.Rest.ClientRuntime" version="[2.3.2]" />
+        <dependency id="Newtonsoft.Json" version="[8.0.3]" />
         <dependency id="System.IdentityModel.Tokens.Jwt" version="[4.0.4.403061554,5.0)" />
-        <dependency id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.4.403061554" />
+        <dependency id="Microsoft.IdentityModel.Protocol.Extensions" version="[1.0.4.403061554]" />
+      </group>
+      <group targetFramework=".NETFramework4.6">
+        <dependency id="Microsoft.AspNet.WebApi.Client" version="[5.2.3]" />
+        <dependency id="Microsoft.AspNet.WebApi.Core" version="[5.2.3]" />
+        <dependency id="Microsoft.Rest.ClientRuntime" version="[2.3.2]" />
+        <dependency id="Newtonsoft.Json" version="[8.0.3]" />
+        <dependency id="System.IdentityModel.Tokens.Jwt" version="[4.0.4.403061554,5.0)" />
+        <dependency id="Microsoft.IdentityModel.Protocol.Extensions" version="[1.0.4.403061554]" />
       </group>
       <group targetFramework=".NETStandard1.6">
         <dependency id="NETStandard.Library" version="1.6.0" />
         <dependency id="Microsoft.AspNetCore.Authentication.JwtBearer" version="1.0.0" />
-        <dependency id="System.IdentityModel.Tokens.Jwt" version="5.0.0" />
+        <dependency id="System.IdentityModel.Tokens.Jwt" version="5.1.4" />
         <dependency id="Microsoft.AspNetCore.Mvc.Core" version="1.0.1" />
         <!-- dependencies for NetCore assembly -->
-        <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="1.0.0" />
-        <dependency id="Microsoft.Extensions.Logging.Abstractions" version="1.0.0" />
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="2.0.0" />
-        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.2" />
-        <dependency id="Newtonsoft.Json" version="9.0.1" />
+        <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="1.1.2" />
+        <dependency id="Microsoft.Extensions.Logging.Abstractions" version="1.1.2" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="2.1.4" />
+        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.10" />
+        <dependency id="Newtonsoft.Json" version="10.0.3" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Microsoft.AspNetCore.Authentication.JwtBearer" version="2.0.0" />
+        <dependency id="Microsoft.AspNetCore.Mvc.Core" version="2.0.0" />
+        <dependency id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" />
+        <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />
+        <dependency id="Microsoft.Extensions.Options" version="2.0.0" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="2.1.4" />
+        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.10" />
+        <dependency id="Newtonsoft.Json" version="10.0.3" />
+        <dependency id="System.Configuration.ConfigurationManager" version="4.4.0" />
+        <dependency id="System.IdentityModel.Tokens.Jwt" version="5.1.4" />
       </group>
     </dependencies>
   </metadata>
@@ -37,13 +57,25 @@
     <file src="bin\release\Microsoft.Bot.Connector.xml" target="lib\net45" />
     <file src="bin\release\Microsoft.Bot.Connector.pdb" target="lib\net45" />
     <!-- assembly Microsoft.Bot.Connector for AspNetCore -->
+    <file src="..\Microsoft.Bot.Connector.AspNetCore\bin\release\net46\Microsoft.Bot.Connector.dll" target="lib\net46" />
+    <file src="..\Microsoft.Bot.Connector.AspNetCore\bin\release\net46\Microsoft.Bot.Connector.pdb" target="lib\net46" />
+    <file src="..\Microsoft.Bot.Connector.AspNetCore\bin\release\net46\Microsoft.Bot.Connector.xml" target="lib\net46" />
     <file src="..\Microsoft.Bot.Connector.AspNetCore\bin\release\netstandard1.6\Microsoft.Bot.Connector.dll" target="lib\netstandard1.6" />
     <file src="..\Microsoft.Bot.Connector.AspNetCore\bin\release\netstandard1.6\Microsoft.Bot.Connector.pdb" target="lib\netstandard1.6" />
     <file src="..\Microsoft.Bot.Connector.AspNetCore\bin\release\netstandard1.6\Microsoft.Bot.Connector.xml" target="lib\netstandard1.6" />
+    <file src="..\Microsoft.Bot.Connector.AspNetCore\bin\release\netstandard2.0\Microsoft.Bot.Connector.dll" target="lib\netstandard2.0" />
+    <file src="..\Microsoft.Bot.Connector.AspNetCore\bin\release\netstandard2.0\Microsoft.Bot.Connector.pdb" target="lib\netstandard2.0" />
+    <file src="..\Microsoft.Bot.Connector.AspNetCore\bin\release\netstandard2.0\Microsoft.Bot.Connector.xml" target="lib\netstandard2.0" />
     <!-- assembly Microsoft.Bot.Connector.NetCore -->
-    <file src="..\Microsoft.Bot.Connector.NetCore\bin\release\Microsoft.Bot.Connector.NetCore.dll" target="lib\netstandard1.6" />
-    <file src="..\Microsoft.Bot.Connector.NetCore\bin\release\Microsoft.Bot.Connector.NetCore.pdb" target="lib\netstandard1.6" />
-    <file src="..\Microsoft.Bot.Connector.NetCore\Content\Microsoft.Bot.Connector.NetCore.xml" target="lib\netstandard1.6" />
+    <file src="..\Microsoft.Bot.Connector.NetCore\bin\release\net46\Microsoft.Bot.Connector.NetCore.dll" target="lib\net46"/>
+    <file src="..\Microsoft.Bot.Connector.NetCore\bin\release\net46\Microsoft.Bot.Connector.NetCore.pdb" target="lib\net46" />
+    <file src="..\Microsoft.Bot.Connector.NetCore\bin\release\net46\Microsoft.Bot.Connector.NetCore.xml" target="lib\net46" />
+    <file src="..\Microsoft.Bot.Connector.NetCore\bin\release\netstandard1.6\Microsoft.Bot.Connector.NetCore.dll" target="lib\netstandard1.6"/>
+    <file src="..\Microsoft.Bot.Connector.NetCore\bin\release\netstandard1.6\Microsoft.Bot.Connector.NetCore.pdb" target="lib\netstandard1.6" />
+    <file src="..\Microsoft.Bot.Connector.NetCore\bin\release\netstandard1.6\Microsoft.Bot.Connector.NetCore.xml" target="lib\netstandard1.6" />
+    <file src="..\Microsoft.Bot.Connector.NetCore\bin\release\netstandard2.0\Microsoft.Bot.Connector.NetCore.dll" target="lib\netstandard2.0"/>
+    <file src="..\Microsoft.Bot.Connector.NetCore\bin\release\netstandard2.0\Microsoft.Bot.Connector.NetCore.pdb" target="lib\netstandard2.0" />
+    <file src="..\Microsoft.Bot.Connector.NetCore\bin\release\netstandard2.0\Microsoft.Bot.Connector.NetCore.xml" target="lib\netstandard2.0" />
     <file src="**\*.cs" exclude="**\obj\**\*.cs" target="src" />
   </files>
 </package>

--- a/CSharp/Library/Microsoft.Bot.Connector.NetFramework/createpackage.cmd
+++ b/CSharp/Library/Microsoft.Bot.Connector.NetFramework/createpackage.cmd
@@ -6,7 +6,10 @@ set errorlevel=0
 mkdir ..\nuget
 erase /s ..\nuget\Microsoft.Bot.Connector*nupkg
 msbuild /property:Configuration=release /p:DefineConstants="NET45" Microsoft.Bot.Connector.csproj 
-msbuild /property:Configuration=release ..\Microsoft.Bot.Connector.NetCore\Microsoft.Bot.Connector.NetCore.csproj 
-msbuild /property:Configuration=release ..\Microsoft.Bot.Connector.AspNetCore\Microsoft.Bot.Connector.AspNetCore.csproj 
+dotnet restore ..\Microsoft.Bot.Connector.NetCore\Microsoft.Bot.Connector.NetCore.csproj 
+dotnet restore ..\Microsoft.Bot.Connector.AspNetCore\Microsoft.Bot.Connector.AspNetCore.csproj 
+dotnet msbuild /property:Configuration=release ..\Microsoft.Bot.Connector.NetCore\Microsoft.Bot.Connector.NetCore.csproj 
+dotnet build --configuration Release ..\Microsoft.Bot.Connector.AspNetCore\Microsoft.Bot.Connector.AspNetCore.csproj
 for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\Microsoft.Bot.Connector.dll).FileVersionInfo.FileVersion"') do set version=%%v
-..\..\packages\NuGet.CommandLine.4.1.0\tools\NuGet.exe pack Microsoft.Bot.Connector.nuspec -symbols -properties version=%version% -OutputDirectory ..\nuget
+rem ..\..\packages\NuGet.CommandLine.4.1.0\tools\NuGet.exe pack Microsoft.Bot.Connector.nuspec -symbols -properties version=%version% -OutputDirectory ..\nuget
+dotnet pack -c Release --no-build --include-symbols ..\Microsoft.Bot.Connector.AspNetCore\Microsoft.Bot.Connector.AspNetCore.csproj

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/CredentialProvider.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/CredentialProvider.cs
@@ -105,5 +105,17 @@ namespace Microsoft.Bot.Connector
             this.Password = configuration.GetSection(passwordKey)?.Value;
         }
     }
+
+    public static class SettingsUtils
+    {
+        public static string GetAppSettings(string key)
+        {
+#if !NETSTANDARD1_6
+            return Environment.GetEnvironmentVariable(key, EnvironmentVariableTarget.Process);
+#else
+            return String.Empty;
+#endif
+        }
+    }
 #endif
 }

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/MicrosoftAppCredentials.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/MicrosoftAppCredentials.cs
@@ -68,6 +68,18 @@ namespace Microsoft.Bot.Connector
             MicrosoftAppId = appId;
             MicrosoftAppPassword = password;
 
+#if !NETSTANDARD1_6
+            if(appId == null)
+            {
+                MicrosoftAppId = Environment.GetEnvironmentVariable(MicrosoftAppIdKey, EnvironmentVariableTarget.Process);
+            }
+
+            if(password == null)
+            {
+                MicrosoftAppPassword = Environment.GetEnvironmentVariable(MicrosoftAppPasswordKey, EnvironmentVariableTarget.Process);
+            }
+#endif
+
             TokenCacheKey = $"{MicrosoftAppId}-cache";
             this.logger = logger;
         }


### PR DESCRIPTION
## convert project file to support .Net Standard 2.0

convert each project file

* Microsoft.Bot.Builder
* Microsoft.Bot.Builder.Autofac
* Microsoft.Bot.Connector.AspNetCore
* Microsoft.Bot.Connector.NetCore

## add bot framework authentication to Microsoft.Bot.Connector.AspNetCore with ASP.Net Core 2

---
add Setup.cs

```csharp
public void ConfigureServices(IServiceCollection services)
{
    services.AddAuthentication().AddBot("{AppId}", "{AppPassword}");
}
```

---
add MessagesController.cs

```csharp
[BotAuthentication]
[HttpPost]
public async Task Post([FromBody]Activity activity)
```
