### PR TITLE
Add null check to make sure prompt dialog on top of stack is available

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/BotToUser.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/BotToUser.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
                     {
                         var topOfStack = stack.Frames[0].Target;
                         // if there is a prompt dialog on top of stack, the InputHint will be set to Expecting
-                        if (topOfStack.GetType().DeclaringType == typeof(PromptDialog))
+                        if (topOfStack != null && topOfStack.GetType().DeclaringType == typeof(PromptDialog))
                         {
                             toUser.InputHint = InputHints.ExpectingInput;
                         }


### PR DESCRIPTION
The module to forward message from bot to the user verifies if there is any prompt dialog to check if the bot is expecting any input. This prompt dialog may be null if the resume after function is static and it requires a null check to avoid null references.