### PR TITLE
Add missing processEvent method to definitions file

### DIFF
--- a/Node/core/lib/botbuilder.d.ts
+++ b/Node/core/lib/botbuilder.d.ts
@@ -7,29 +7,29 @@
 /**
  * Text based prompts that can be sent to a user.
  * * _{string}_ - A simple message to send the user.
- * * _{string[]}_ - Array of possible messages to send the user. One will be chosen at random. 
+ * * _{string[]}_ - Array of possible messages to send the user. One will be chosen at random.
  */
 export type TextType = string|string[];
 
 /**
  * Message based prompts that can be sent to a user.
- * * _{IMessage}_ - Message to send the user expressed using JSON. The message can contain attachments and suggested actions. Not all channels natively support all message properties but most channels will down render unsupported fields. 
- * * _{IIsMessage}_ - An instance of the [Message](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.message.html) builder class. This class helps to localize your messages and provides helpers to aid with formatting the text portions of your message. 
+ * * _{IMessage}_ - Message to send the user expressed using JSON. The message can contain attachments and suggested actions. Not all channels natively support all message properties but most channels will down render unsupported fields.
+ * * _{IIsMessage}_ - An instance of the [Message](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.message.html) builder class. This class helps to localize your messages and provides helpers to aid with formatting the text portions of your message.
  */
 export type MessageType = IMessage|IIsMessage;
 
 /**
  * Flexible range of possible prompts that can be sent to a user.
  * * _{string}_ - A simple message to send the user.
- * * _{string[]}_ - Array of possible messages to send the user. One will be chosen at random. 
- * * _{IMessage}_ - Message to send the user expressed using JSON. The message can contain attachments and suggested actions. Not all channels natively support all message properties but most channels will down render unsupported fields. 
- * * _{IIsMessage}_ - An instance of the [Message](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.message.html) builder class. This class helps to localize your messages and provides helpers to aid with formatting the text portions of your message. 
+ * * _{string[]}_ - Array of possible messages to send the user. One will be chosen at random.
+ * * _{IMessage}_ - Message to send the user expressed using JSON. The message can contain attachments and suggested actions. Not all channels natively support all message properties but most channels will down render unsupported fields.
+ * * _{IIsMessage}_ - An instance of the [Message](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.message.html) builder class. This class helps to localize your messages and provides helpers to aid with formatting the text portions of your message.
  */
 export type TextOrMessageType = string|string[]|IMessage|IIsMessage;
 
 /**
  * Some methods can take either an `IAttachment` in JSON form or one the various card builder classes
- * that implement `IIsAttachment`. 
+ * that implement `IIsAttachment`.
  */
 export type AttachmentType = IAttachment|IIsAttachment;
 
@@ -37,13 +37,13 @@ export type AttachmentType = IAttachment|IIsAttachment;
  * Supported rules for matching a users utterance.
  * * _{RegExp}_ - A regular expression will be used to match the users utterance.
  * * _{string}_ - A named intent returned from a recognizer will be used to match the users utterance.
- * * _{(RegExp|string)[]}_ - An array of either regular expressions or named intents can be passed to match the users utterance in a number of possible ways. The rule generating the highest score (best match) will be used for scoring purposes. 
+ * * _{(RegExp|string)[]}_ - An array of either regular expressions or named intents can be passed to match the users utterance in a number of possible ways. The rule generating the highest score (best match) will be used for scoring purposes.
  */
 export type MatchType = RegExp|string|(RegExp|string)[];
 
 /**
  * List of text values. The values can be expressed as a pipe delimited string like "value1|value2|value3"
- * or simple array of values.  
+ * or simple array of values.
  */
 export type ValueListType = string|string[];
 
@@ -74,10 +74,10 @@ export interface IEvent {
     sourceEvent: any;
 
     /** Address routing information for the event. Save this field to external storage somewhere to later compose a proactive message to the user. */
-    address: IAddress; 
+    address: IAddress;
 
-    /** 
-     * For incoming messages this is the user that sent the message. By default this is a copy of [address.user](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iaddress.html#user) but you can configure your bot with a 
+    /**
+     * For incoming messages this is the user that sent the message. By default this is a copy of [address.user](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iaddress.html#user) but you can configure your bot with a
      * [lookupUser](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iuniversalbotsettings.html#lookupuser) function that lets map the incoming user to an internal user id.
      */
     user: IIdentity;
@@ -86,8 +86,8 @@ export interface IEvent {
     replyToId?: string;
 }
 
-/** 
- * The Properties of a conversation have changed.  
+/**
+ * The Properties of a conversation have changed.
  * @example
  * <pre><code>
  * bot.on('conversationUpdate', function (update) {
@@ -104,7 +104,7 @@ export interface IConversationUpdate extends IEvent {
 
     /** Array of reactions added to an activity. */
     reactionsAdded?: IMessageReaction[];
-    
+
     /** Array of reactions removed from an activity. */
     reactionsRemoved?: IMessageReaction[];
 
@@ -115,8 +115,8 @@ export interface IConversationUpdate extends IEvent {
     historyDisclosed?: boolean;
 }
 
-/** 
- * The Properties of a message have changed.  
+/**
+ * The Properties of a message have changed.
  * @example
  * <pre><code>
  * bot.on('messageReaction', function (update) {
@@ -127,7 +127,7 @@ export interface IConversationUpdate extends IEvent {
 export interface IMessageUpdate extends IEvent {
     /** Array of reactions added to an activity. */
     reactionsAdded?: IMessageReaction[];
-    
+
     /** Array of reactions removed from an activity. */
     reactionsRemoved?: IMessageReaction[];
 }
@@ -138,8 +138,10 @@ export interface IMessageReaction {
     type: string;
 }
 
-/** 
- * A user has updated their contact list. 
+/**
+ * A user has updated their contact list.
+/**
+ * A user has updated their contact list.
  * @example
  * <pre><code>
  * bot.on('contactRelationUpdate', function (update) {
@@ -152,18 +154,18 @@ export interface IContactRelationUpdate extends IEvent {
     action: string;
 }
 
-/** 
- * A chat message sent between a User and a Bot. Messages from the bot to the user come in two flavors: 
- * 
- * * __reactive messages__ are messages sent from the Bot to the User as a reply to an incoming message from the user. 
- * * __proactive messages__ are messages sent from the Bot to the User in response to some external event like an alarm triggering.
- * 
- * In the reactive case the you should copy the [address](#address) field from the incoming message to the outgoing message (if you use the [Message]( /en-us/node/builder/chat-reference/classes/_botbuilder_d_.message.html) builder class and initialize it with the 
- * [session](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session.html) this will happen automatically) and then set the [text](#text) or [attachments](#attachments).  For proactive messages you’ll need save the [address](#address) from the incoming message to 
- * an external storage somewhere. You can then later pass this in to [UniversalBot.beginDialog()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.universalbot.html#begindialog) or copy it to an outgoing message passed to 
- * [UniversalBot.send()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.universalbot.html#send). 
+/**
+ * A chat message sent between a User and a Bot. Messages from the bot to the user come in two flavors:
  *
- * Composing a message to the user using the incoming address object will by default send a reply to the user in the context of the current conversation. Some channels allow for the starting of new conversations with the user. To start a new proactive conversation with the user simply delete 
+ * * __reactive messages__ are messages sent from the Bot to the User as a reply to an incoming message from the user.
+ * * __proactive messages__ are messages sent from the Bot to the User in response to some external event like an alarm triggering.
+ *
+ * In the reactive case the you should copy the [address](#address) field from the incoming message to the outgoing message (if you use the [Message]( /en-us/node/builder/chat-reference/classes/_botbuilder_d_.message.html) builder class and initialize it with the
+ * [session](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session.html) this will happen automatically) and then set the [text](#text) or [attachments](#attachments).  For proactive messages you’ll need save the [address](#address) from the incoming message to
+ * an external storage somewhere. You can then later pass this in to [UniversalBot.beginDialog()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.universalbot.html#begindialog) or copy it to an outgoing message passed to
+ * [UniversalBot.send()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.universalbot.html#send).
+ *
+ * Composing a message to the user using the incoming address object will by default send a reply to the user in the context of the current conversation. Some channels allow for the starting of new conversations with the user. To start a new proactive conversation with the user simply delete
  * the [conversation](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iaddress.html#conversation) field from the address object before composing the outgoing message.
  * @example
  * <pre><code>
@@ -180,7 +182,7 @@ export interface IMessage extends IEvent {
     /** Local time when message was sent (set by client or bot, Ex: 2016-09-23T13:07:49.4714686-07:00.) */
     localTimestamp?: string;
 
-    /** Text to be displayed by as fall-back and as short description of the message content in e.g. list of recent conversations. */  
+    /** Text to be displayed by as fall-back and as short description of the message content in e.g. list of recent conversations. */
     summary?: string;
 
     /** Spoken message as [Speech Synthesis Markup Language](https://msdn.microsoft.com/en-us/library/hh378377(v=office.14).aspx). */
@@ -189,11 +191,11 @@ export interface IMessage extends IEvent {
     /** Message text. */
     text?: string;
 
-    /** Identified language of the message text if known. */   
+    /** Identified language of the message text if known. */
     textLocale?: string;
 
     /** For incoming messages contains attachments like images sent from the user. For outgoing messages contains objects like cards or images to send to the user.   */
-    attachments?: IAttachment[]; 
+    attachments?: IAttachment[];
 
     /** Structured objects passed to the bot or user. */
     entities?: any[];
@@ -201,8 +203,8 @@ export interface IMessage extends IEvent {
     /** Format of text fields. The default value is 'markdown'. */
     textFormat?: string;
 
-    /** Hint for how clients should layout multiple attachments. The default value is 'list'. */ 
-    attachmentLayout?: string; 
+    /** Hint for how clients should layout multiple attachments. The default value is 'list'. */
+    attachmentLayout?: string;
 
     /** Hint for clients letting them know if the bot is expecting further input or not. The built-in prompts will automatically populate this value for outgoing messages. */
     inputHint?: string;
@@ -220,8 +222,8 @@ export interface IMessage extends IEvent {
     code?: string;
 }
 
-/** 
- * Implemented by classes that can be converted into an IMessage, like the [Message](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.message) builder class. 
+/**
+ * Implemented by classes that can be converted into an IMessage, like the [Message](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.message) builder class.
  * @example
  * <pre><code>
  * var msg = new builder.Message(session)
@@ -234,8 +236,8 @@ export interface IIsMessage {
     toMessage(): IMessage;
 }
 
-/** 
- * Optional message properties that can be sent to things like prompts or [session.say()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session#say). 
+/**
+ * Optional message properties that can be sent to things like prompts or [session.say()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session#say).
  * @example
  * <pre><code>
  * session.say("Please wait...", "<speak>Please wait</speak>", {
@@ -245,7 +247,7 @@ export interface IIsMessage {
  */
 export interface IMessageOptions {
     /** For incoming messages contains attachments like images sent from the user. For outgoing messages contains objects like cards or images to send to the user.   */
-    attachments?: IAttachment[]; 
+    attachments?: IAttachment[];
 
     /** Structured objects passed to the bot or user. */
     entities?: any[];
@@ -253,8 +255,8 @@ export interface IMessageOptions {
     /** Format of text fields. The default value is 'markdown'. */
     textFormat?: string;
 
-    /** Hint for how clients should layout multiple attachments. The default value is 'list'. */ 
-    attachmentLayout?: string; 
+    /** Hint for how clients should layout multiple attachments. The default value is 'list'. */
+    attachmentLayout?: string;
 
     /** Hint for clients letting them know if the bot is expecting further input or not. The built-in prompts will automatically populate this value for outgoing messages. */
     inputHint?: string;
@@ -265,20 +267,20 @@ export interface IIdentity {
     /** Channel specific ID for this identity. */
     id: string;
 
-    /** Friendly name for this identity. */ 
+    /** Friendly name for this identity. */
     name?: string;
 
-    /** If true the identity is a group. Typically only found on conversation identities. */ 
-    isGroup?: boolean;   
+    /** If true the identity is a group. Typically only found on conversation identities. */
+    isGroup?: boolean;
 }
 
-/** 
- * Address routing information for an [event](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.ievent.html#address). 
- * Addresses are bidirectional meaning they can be used to address both incoming and outgoing events. 
- * They're also connector specific meaning that [connectors](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iconnector.html) 
+/**
+ * Address routing information for an [event](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.ievent.html#address).
+ * Addresses are bidirectional meaning they can be used to address both incoming and outgoing events.
+ * They're also connector specific meaning that [connectors](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iconnector.html)
  * are free to add their own fields to the address.
- * 
- * To send a __proactive message__ to a user bots should save the address from a received [message](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.imessage). 
+ *
+ * To send a __proactive message__ to a user bots should save the address from a received [message](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.imessage).
  * Depending on the channel addresses can change, so bots should periodically update the address stored for a given
  * user.
  */
@@ -289,14 +291,14 @@ export interface IAddress {
     /** User that sent or should receive the message. */
     user: IIdentity;
 
-    /** Bot that either received or is sending the message. */ 
+    /** Bot that either received or is sending the message. */
     bot: IIdentity;
 
-    /** 
-     * Represents the current conversation and tracks where replies should be routed to. 
+    /**
+     * Represents the current conversation and tracks where replies should be routed to.
      * Can be deleted to start a new conversation with a [user](#user) on channels that support new conversations.
-     */ 
-    conversation?: IIdentity;  
+     */
+    conversation?: IIdentity;
 }
 
 /** [ChatConnector](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.chatconnector) specific address. */
@@ -304,7 +306,7 @@ export interface IChatConnectorAddress extends IAddress {
     /** Incoming Message ID. */
     id?: string;
 
-    /** Specifies the URL to post messages back. */ 
+    /** Specifies the URL to post messages back. */
     serviceUrl?: string;
 }
 
@@ -326,23 +328,23 @@ export interface IStartConversationAddress extends IChatConnectorAddress {
     topicName?: string;
 }
 
-/**  
- * Many messaging channels provide the ability to attach richer objects. Bot Builder lets you express these attachments in a cross channel way and [connectors](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iconnector.html) will do their best to render the 
- * attachments using the channels native constructs. If you desire more control over the channels rendering of a message you can use [IEvent.sourceEvent](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.ievent.html#sourceevent) to provide attachments using 
+/**
+ * Many messaging channels provide the ability to attach richer objects. Bot Builder lets you express these attachments in a cross channel way and [connectors](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iconnector.html) will do their best to render the
+ * attachments using the channels native constructs. If you desire more control over the channels rendering of a message you can use [IEvent.sourceEvent](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.ievent.html#sourceevent) to provide attachments using
  * the channels native schema. The types of attachments that can be sent varies by channel but these are the basic types:
- * 
+ *
  * * __Media and Files:__  Basic files can be sent by setting [contentType](#contenttype) to the MIME type of the file and then passing a link to the file in [contentUrl](#contenturl).
  * * __Cards:__  A rich set of visual cards can by setting [contentType](#contenttype) to the cards type and then passing the JSON for the card in [content](#content). If you use one of the rich card builder classes like
- * [HeroCard](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.herocard.html) the attachment will automatically filled in for you.    
+ * [HeroCard](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.herocard.html) the attachment will automatically filled in for you.
  */
 export interface IAttachment {
     /** MIME type string which describes type of attachment. */
     contentType: string;
 
-    /** (Optional) object structure of attachment. */  
+    /** (Optional) object structure of attachment. */
     content?: any;
 
-    /** (Optional) reference to location of attachment content. */  
+    /** (Optional) reference to location of attachment content. */
     contentUrl?: string;
 
     /** (Optional) name of the attachment. */
@@ -363,32 +365,32 @@ export interface ISigninCard {
     /** Title of the Card. */
     title: string;
 
-    /** Sign in action. */  
-    buttons: ICardAction[];  
+    /** Sign in action. */
+    buttons: ICardAction[];
 }
 
-/** 
- * Displays a card to the user using either a smaller thumbnail layout or larger hero layout (the attachments [contentType](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iattachment.html#contenttype) determines which). 
- * All of the cards fields are optional so this card can be used to specify things like a keyboard on certain channels. Some channels may choose to render a lower fidelity version of the card or use an alternate representation. 
+/**
+ * Displays a card to the user using either a smaller thumbnail layout or larger hero layout (the attachments [contentType](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iattachment.html#contenttype) determines which).
+ * All of the cards fields are optional so this card can be used to specify things like a keyboard on certain channels. Some channels may choose to render a lower fidelity version of the card or use an alternate representation.
  */
 export interface IThumbnailCard {
     /** Title of the Card. */
     title?: string;
 
-    /** Subtitle appears just below Title field, differs from Title in font styling only. */  
+    /** Subtitle appears just below Title field, differs from Title in font styling only. */
     subtitle?: string;
 
     /** Text field appears just below subtitle, differs from Subtitle in font styling only. */
     text?: string;
 
-    /** Messaging supports all media formats: audio, video, images and thumbnails as well to optimize content download. */  
+    /** Messaging supports all media formats: audio, video, images and thumbnails as well to optimize content download. */
     images?: ICardImage[];
 
-    /** This action will be activated when user taps on the card. Not all channels support tap actions and some channels may choose to render the tap action as the titles link. */  
+    /** This action will be activated when user taps on the card. Not all channels support tap actions and some channels may choose to render the tap action as the titles link. */
     tap?: ICardAction;
 
-    /** Set of actions applicable to the current card. Not all channels support buttons or cards with buttons. Some channels may choose to render the buttons using a custom keyboard. */  
-    buttons?: ICardAction[];  
+    /** Set of actions applicable to the current card. Not all channels support buttons or cards with buttons. Some channels may choose to render the buttons using a custom keyboard. */
+    buttons?: ICardAction[];
 }
 
 /** Displays a rich receipt to a user for something they've either bought or are planning to buy. */
@@ -396,50 +398,50 @@ export interface IReceiptCard {
     /** Title of the Card. */
     title: string;
 
-    /** Array of receipt items. */  
+    /** Array of receipt items. */
     items: IReceiptItem[];
 
-    /** Array of additional facts to display to user (shipping charges and such.) Not all facts will be displayed on all channels. */ 
+    /** Array of additional facts to display to user (shipping charges and such.) Not all facts will be displayed on all channels. */
     facts: IFact[];
 
-    /** This action will be activated when user taps on the card. Not all channels support tap actions. */  
+    /** This action will be activated when user taps on the card. Not all channels support tap actions. */
     tap: ICardAction;
 
-    /** Total amount of money paid (or should be paid.) */  
+    /** Total amount of money paid (or should be paid.) */
     total: string;
 
     /** Total amount of TAX paid (or should be paid.) */
     tax: string;
 
-    /** Total amount of VAT paid (or should be paid.) */  
+    /** Total amount of VAT paid (or should be paid.) */
     vat: string;
 
-    /** Set of actions applicable to the current card. Not all channels support buttons and the number of allowed buttons varies by channel. */  
-    buttons: ICardAction[];  
+    /** Set of actions applicable to the current card. Not all channels support buttons and the number of allowed buttons varies by channel. */
+    buttons: ICardAction[];
 }
 
 /** An individual item within a [receipt](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.ireceiptcard.html). */
 export interface IReceiptItem {
     /** Title of the item. */
     title: string;
-    
+
     /** Subtitle appears just below Title field, differs from Title in font styling only. On some channels may be combined with the [title](#title) or [text](#text). */
     subtitle: string;
 
-    /** Text field appears just below subtitle, differs from Subtitle in font styling only. */  
+    /** Text field appears just below subtitle, differs from Subtitle in font styling only. */
     text: string;
 
-    /** Image to display on the card. Some channels may either send the image as a separate message or simply include a link to the image. */  
+    /** Image to display on the card. Some channels may either send the image as a separate message or simply include a link to the image. */
     image: ICardImage;
-    
+
     /** Amount with currency. */
     price: string;
 
-    /** Number of items of given kind. */  
+    /** Number of items of given kind. */
     quantity: string;
 
-    /** This action will be activated when user taps on the Item bubble. Not all channels support tap actions. */  
-    tap: ICardAction;  
+    /** This action will be activated when user taps on the Item bubble. Not all channels support tap actions. */
+    tap: ICardAction;
 }
 
 /** Implemented by classes that can be converted into a receipt item. */
@@ -453,13 +455,13 @@ export interface ICardAction {
     /** Defines the type of action implemented by this button. Not all action types are supported by all channels. */
     type: string;
 
-    /** Text description for button actions. */   
+    /** Text description for button actions. */
     title?: string;
 
-    /** Parameter for Action. Content of this property depends on Action type. */  
+    /** Parameter for Action. Content of this property depends on Action type. */
     value: string;
 
-    /** (Optional) Picture to display for button actions. Not all channels support button images. */  
+    /** (Optional) Picture to display for button actions. Not all channels support button images. */
     image?: string;
 
     /** (Optional) Text for this action. */
@@ -477,10 +479,10 @@ export interface IIsCardAction {
 
 /** Suggested actions to send to the user and displayed as quick replies. Suggested actions will be displayed only on the channels that support suggested actions. */
 export interface ISuggestedActions {
-    
+
     /** Optional recipients of the suggested actions. Not supported in all channels. */
     to?: string[];
-    
+
     /** Quick reply actions that can be suggested as part of the message. */
     actions: ICardAction[];
 }
@@ -496,11 +498,11 @@ export interface ICardImage {
     /** Thumbnail image for major content property. */
     url: string;
 
-    /** Image description intended for screen readers. Not all channels will support alt text. */  
+    /** Image description intended for screen readers. Not all channels will support alt text. */
     alt: string;
 
-    /** Action assigned to specific Attachment. E.g. navigate to specific URL or play/open media content. Not all channels will support tap actions. */  
-    tap: ICardAction;  
+    /** Action assigned to specific Attachment. E.g. navigate to specific URL or play/open media content. Not all channels will support tap actions. */
+    tap: ICardAction;
 }
 
 /** Implemented by classes that can be converted into a card image. */
@@ -514,8 +516,8 @@ export interface IFact {
     /** Display name of the fact. */
     key: string;
 
-    /** Display value of the fact. */  
-    value: string;  
+    /** Display value of the fact. */
+    value: string;
 }
 
 /** Implemented by classes that can be converted into a fact. */
@@ -540,8 +542,8 @@ export interface ILocalizer {
      * @param locale The locale to load.
      * @param callback callback that is called once the supplied locale has been loaded, or an error if the load fails.
      */
-    load(locale: string, callback: (err: Error) => void): void;     
-    
+    load(locale: string, callback: (err: Error) => void): void;
+
     /**
      * Loads a localized string for the specified language.
      * @param locale Desired locale of the string to return.
@@ -549,7 +551,7 @@ export interface ILocalizer {
      * @param namespace (Optional) namespace for the msgid keys.
      */
     trygettext(locale: string, msgid: string, namespace?: string): string;
-    
+
     /**
      * Loads a localized string for the specified language.
      * @param locale Desired locale of the string to return.
@@ -590,8 +592,8 @@ export interface IDialogState {
     state: any;
 }
 
-/** 
-  * Results returned by a child dialog to its parent via a call to session.endDialog(). 
+/**
+  * Results returned by a child dialog to its parent via a call to session.endDialog().
   */
 export interface IDialogResult<T> {
     /** The reason why the current dialog is being resumed. Defaults to [ResumeReason.completed](/en-us/node/builder/chat-reference/enums/_botbuilder_d_.resumereason#completed). */
@@ -614,10 +616,10 @@ export interface IRecognizeContext {
 
     /** Data for the user that's persisted across all conversations with the bot. */
     userData: any;
-    
+
     /** Shared conversation data that's visible to all members of the conversation. */
     conversationData: any;
-    
+
     /** Private conversation data that's only visible to the user. */
     privateConversationData: any;
 
@@ -635,14 +637,14 @@ export interface IRecognizeContext {
 
     /**
      * Loads a localized string for the messages language. If arguments are passed the localized string
-     * will be treated as a template and formatted using [sprintf-js](https://github.com/alexei/sprintf.js) (see their docs for details.) 
+     * will be treated as a template and formatted using [sprintf-js](https://github.com/alexei/sprintf.js) (see their docs for details.)
      * @param msgid String to use as a key in the localized string table. Typically this will just be the english version of the string.
-     * @param args (Optional) arguments used to format the final output string. 
+     * @param args (Optional) arguments used to format the final output string.
      */
     gettext(msgid: string, ...args: any[]): string;
 
     /**
-     * Loads the plural form of a localized string for the messages language. The output string will be formatted to 
+     * Loads the plural form of a localized string for the messages language. The output string will be formatted to
      * include the count by replacing %d in the string with the count.
      * @param msgid Singular form of the string to use as a key in the localized string table. Use %d to specify where the count should go.
      * @param msgid_plural Plural form of the string to use as a key in the localized string table. Use %d to specify where the count should go.
@@ -680,14 +682,14 @@ export interface IFindActionRouteContext extends IRecognizeContext {
 
 /** Options passed when defining a dialog action. */
 export interface IDialogActionOptions {
-    /** 
-     * (Optional) intent(s) used to trigger the action. Either a regular expression or a named 
-     * intent can be provided and multiple intents can be specified.  When a named intent is 
+    /**
+     * (Optional) intent(s) used to trigger the action. Either a regular expression or a named
+     * intent can be provided and multiple intents can be specified.  When a named intent is
      * provided the action will be matched using the recognizers assigned to the library/bot using
-     * [Library.recognizer()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.library#recognizer). 
-     * 
+     * [Library.recognizer()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.library#recognizer).
+     *
      * If a matches option isn't provided then the action can only be matched if an [onFindAction](#onfindaction)
-     * handler is provided. 
+     * handler is provided.
      */
     matches?: MatchType;
 
@@ -695,21 +697,21 @@ export interface IDialogActionOptions {
     intentThreshold?: number;
 
     /**
-     * (Optional) custom handler that's invoked whenever the action is being checked to see if it 
-     * should be triggered. The handler is passed a context object containing the received message 
+     * (Optional) custom handler that's invoked whenever the action is being checked to see if it
+     * should be triggered. The handler is passed a context object containing the received message
      * and any intents detected. The handler should return a confidence score for 0.0 to 1.0 and
-     * routeData that should be passed in during the `selectActionRoute` call.   
+     * routeData that should be passed in during the `selectActionRoute` call.
      */
     onFindAction?: (context: IFindActionRouteContext, callback: (err: Error, score: number, routeData?: IActionRouteData) => void) => void;
 
     /**
      * (Optional) custom handler that's invoked whenever the action is triggered.  This lets you
      * customize the behavior of an action. For instance you could clear the dialog stack before
-     * the new dialog is started, changing the default behavior which is to just push the new 
-     * dialog onto the end of the stack. 
-     * 
-     * It's important to note that this is not a waterfall and you should call `next()` if you 
-     * would like the actions default behavior to run. 
+     * the new dialog is started, changing the default behavior which is to just push the new
+     * dialog onto the end of the stack.
+     *
+     * It's important to note that this is not a waterfall and you should call `next()` if you
+     * would like the actions default behavior to run.
      */
     onSelectAction?: (session: Session, args?: IActionRouteData, next?: Function) => void;
 }
@@ -724,18 +726,18 @@ export interface IBeginDialogActionOptions extends IDialogActionOptions {
 /** Options passed when defining a `triggerAction()`. */
 export interface ITriggerActionOptions extends IBeginDialogActionOptions {
     /**
-     * If specified the user will be asked to confirm that they are ok canceling the current 
+     * If specified the user will be asked to confirm that they are ok canceling the current
      * uncompleted task.
      */
     confirmPrompt?: TextOrMessageType;
 
-    /** 
-     * (Optional) custom handler called when a root dialog is being interrupted by another root 
+    /**
+     * (Optional) custom handler called when a root dialog is being interrupted by another root
      * dialog. This gives the dialog an opportunity to perform custom cleanup logic or to prompt
-     * the user to confirm the interruption was intended. 
-     * 
-     * It's important to note that this is not a waterfall and you should call `next()` if you 
-     * would like the actions default behavior to run. 
+     * the user to confirm the interruption was intended.
+     *
+     * It's important to note that this is not a waterfall and you should call `next()` if you
+     * would like the actions default behavior to run.
      */
     onInterrupted?: (session: Session, dialogId: string, dialogArgs?: any, next?: Function) => void;
 }
@@ -744,7 +746,7 @@ export interface ITriggerActionOptions extends IBeginDialogActionOptions {
 export interface ICancelActionOptions extends IDialogActionOptions {
     /**
      * If specified the user will be asked to confirm that they truly would like to cancel an
-     * action when triggered. 
+     * action when triggered.
      */
     confirmPrompt?: TextOrMessageType;
 }
@@ -757,7 +759,7 @@ export interface IActionRouteData {
     /** Intent that triggered the action. */
     intent?: IIntentRecognizerResult;
 
-    /** Optional data passed as part of the action binding. */    
+    /** Optional data passed as part of the action binding. */
     data?: string;
 
     /** ID of the dialog the action is bound to. */
@@ -767,9 +769,9 @@ export interface IActionRouteData {
     dialogIndex?: number;
 }
 
-/** 
+/**
  * A choice that can be passed to [Prompts.choice()](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.__global.iprompts#choice)
- * or [PromptRecognizers.recognizeChoices()][/en-us/node/builder/chat-reference/classes/_botbuilder_d_.promptrecognizers#recognizechoices]. 
+ * or [PromptRecognizers.recognizeChoices()][/en-us/node/builder/chat-reference/classes/_botbuilder_d_.promptrecognizers#recognizechoices].
  */
 export interface IChoice {
     /** Value to return when selected.  */
@@ -802,17 +804,17 @@ export interface IPromptRecognizeTimesOptions {
 
 /** Options passed to [PromptRecognizers.recognizeValues()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.promptrecognizers#recognizevalues). */
 export interface IPromptRecognizeValuesOptions {
-    /** 
-     * (Optional) if true, then only some of the tokens in a value need to exist to be considered 
+    /**
+     * (Optional) if true, then only some of the tokens in a value need to exist to be considered
      * a match. The default value is "false".
      */
     allowPartialMatches?: boolean;
 
-    /** 
+    /**
      * (Optional) maximum tokens allowed between two matched tokens in the utterance. So with
      * a max distance of 2 the value "second last" would match the utterance "second from the last"
-     * but it wouldn't match "Wait a second. That's not the last one is it?". 
-     * The default value is "2".  
+     * but it wouldn't match "Wait a second. That's not the last one is it?".
+     * The default value is "2".
      */
     maxTokenDistance?: number;
 }
@@ -828,7 +830,7 @@ export interface IPromptRecognizeChoicesOptions extends IPromptRecognizeValuesOp
 
 /** Options passed to the [built-in prompts](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.__global.iprompts). */
 export interface IPromptOptions extends IMessageOptions {
-    /** 
+    /**
      * (Optional) Initial prompt to send the user. This is typically populated by the `Prompts.xxx()` function.
      */
     prompt?: TextOrMessageType;
@@ -836,9 +838,9 @@ export interface IPromptOptions extends IMessageOptions {
     /** (Optional) SSML to send with the initial `prompt`. If the prompt is of type `IMessage` or `IIsMessage`, this value will be ignored. If this value is an array a response will be chosen at random. */
     speak?: TextType;
 
-    /** 
-     * (Optional) retry prompt to send if the users response isn't understood. Default is to just 
-     * re-prompt with a customizable system prompt. 
+    /**
+     * (Optional) retry prompt to send if the users response isn't understood. Default is to just
+     * re-prompt with a customizable system prompt.
      */
     retryPrompt?: TextOrMessageType;
 
@@ -864,16 +866,16 @@ export interface IPromptOptions extends IMessageOptions {
     localizationNamespace?: string;
 }
 
-/** 
- * Contextual information tracked for a [Prompt](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.prompt). This information can be accessed 
- * within a prompt through [session.dialogData](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session#dialogdata).  
+/**
+ * Contextual information tracked for a [Prompt](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.prompt). This information can be accessed
+ * within a prompt through [session.dialogData](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session#dialogdata).
  */
 export interface IPromptContext {
     /** Options that the prompt was called with. */
     options: IPromptOptions;
 
-    /** 
-     * Number of times the user has interacted with the prompt. The first message sent to the user 
+    /**
+     * Number of times the user has interacted with the prompt. The first message sent to the user
      * is turn-0, the users first reply is turn-1, and so forth.
      */
     turns: number;
@@ -881,14 +883,14 @@ export interface IPromptContext {
     /** Timestamp of the last turn. */
     lastTurn: number;
 
-    /** 
-     * If true, we're returning from an unexpected interruption and should send the initial turn-0 
-     * prompt again.  
+    /**
+     * If true, we're returning from an unexpected interruption and should send the initial turn-0
+     * prompt again.
      */
     isReprompt: boolean;
 
-    /** 
-     * Used to track which [Prompt.matches()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.prompt#matches) handler is active. This is 
+    /**
+     * Used to track which [Prompt.matches()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.prompt#matches) handler is active. This is
      * used internally to move the handlers waterfall to the next step.
      */
     activeIntent: string;
@@ -927,23 +929,23 @@ export interface IPromptChoiceFeatures extends IPromptFeatures {
     minScore?: number;
 }
 
-/** 
+/**
  * Options passed to [Prompts.choice()](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.__global.iprompts#choice)
- * or in a `session.beginDialog()` call to a custom prompt based on the [PromptChoice](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.promptchoice) 
- * class. 
+ * or in a `session.beginDialog()` call to a custom prompt based on the [PromptChoice](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.promptchoice)
+ * class.
  */
 export interface IPromptChoiceOptions extends IPromptOptions {
-    /** 
-     * (Optional) List of choices to present to the user. If omitted a [PromptChoice.onChoices()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.promptchoice#onchoices) 
-     * handler should be provided. 
+    /**
+     * (Optional) List of choices to present to the user. If omitted a [PromptChoice.onChoices()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.promptchoice#onchoices)
+     * handler should be provided.
      */
     choices?: IChoice[];
 }
 
-/** 
+/**
  * Options passed to [Prompts.number()](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.__global.iprompts#number)
- * or in a `session.beginDialog()` call to a custom prompt based on the [PromptNumber](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.promptnumber) 
- * class. 
+ * or in a `session.beginDialog()` call to a custom prompt based on the [PromptNumber](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.promptnumber)
+ * class.
  */
 export interface IPromptNumberOptions extends IPromptOptions {
     /** (Optional) minimum value that can be recognized. */
@@ -971,22 +973,22 @@ export interface IPromptTextOptions extends IPromptOptions {
 
 /** Optional features for [PromptText](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.prompttext) class. */
 export interface IPromptTextFeatures extends IPromptFeatures {
-    /** 
-     * (Optional) The score that should be returned when the prompts [onRecognize()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.prompt#onrecognize) 
-     * handler is called. The default value is "0.5". 
+    /**
+     * (Optional) The score that should be returned when the prompts [onRecognize()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.prompt#onrecognize)
+     * handler is called. The default value is "0.5".
      */
     recognizeScore?: number;
 }
 
-/** 
+/**
  * Options passed to [Prompts.attachment()](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.__global.iprompts#attachment)
- * or in a `session.beginDialog()` call to a custom prompt based on the [PromptAttachment](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.promptattachment) 
- * class. 
+ * or in a `session.beginDialog()` call to a custom prompt based on the [PromptAttachment](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.promptattachment)
+ * class.
  */
 export interface IPromptAttachmentOptions extends IPromptOptions {
-    /** 
-     * (Optional) list of content types the prompt is waiting for. Types ending with '*' will be 
-     * prefixed matched again the received attachment(s). 
+    /**
+     * (Optional) list of content types the prompt is waiting for. Types ending with '*' will be
+     * prefixed matched again the received attachment(s).
      */
     contentTypes?: string|string[];
 }
@@ -997,7 +999,7 @@ export interface IPromptAttachmentFeatures extends IPromptFeatures {
     recognizeScore?: number;
 }
 
-/** 
+/**
  * Route choices to pass to [Prompts.disambiguate()](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.__global.iprompts#disambiguate).
  * The key for the map should be the localized label to display to the user and the value should be
  * the route to select when chosen by the user.  You can pass `null` for the route to give the user the option to cancel.
@@ -1033,7 +1035,7 @@ export interface IPromptTextResult extends IPromptResult<string> { }
 export interface IPromptNumberResult extends IPromptResult<number> { }
 
 /** Strongly typed Confirm Prompt Result. */
-export interface IPromptConfirmResult extends IPromptResult<boolean> { } 
+export interface IPromptConfirmResult extends IPromptResult<boolean> { }
 
 /** Strongly typed Choice Prompt Result. */
 export interface IPromptChoiceResult extends IPromptResult<IFindMatchResult> { }
@@ -1093,11 +1095,11 @@ export interface IIntentRecognizerSetOptions {
 export interface IIntentDialogOptions extends IIntentRecognizerSetOptions {
     /** (Optional) Controls the dialogs processing of incoming user utterances. The default is RecognizeMode.onBeginIfRoot.  The default prior to v3.2 was RecognizeMode.onBegin. */
     recognizeMode?: RecognizeMode;
-} 
+}
 
 /** Interface implemented by intent recognizer plugins like the [LuisRecognizer](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.luisrecognizer.html) class. */
 export interface IIntentRecognizer {
-    /** 
+    /**
      * Attempts to match a users text utterance to an intent.
      * @param context Contextual information for a received message that's being recognized.
      * @param callback Function to invoke with the results of the recognition operation.
@@ -1128,7 +1130,7 @@ export interface IIntentRecognizerResult extends IRecognizeResult {
     intents?: IIntent[];
 
     /** List of entities recognized. */
-    entities?: IEntity[]; 
+    entities?: IEntity[];
 }
 
 /** Options passed to the constructor of a session. */
@@ -1156,7 +1158,7 @@ export interface ISessionOptions {
 
     /** (Optional) arguments to pass to the conversations initial dialog. */
     dialogArgs?: any;
-    
+
     /** (Optional) time to allow between each message sent as a batch. The default value is 250ms.  */
     autoBatchDelay?: number;
 
@@ -1205,9 +1207,9 @@ export interface IBotStorageData {
     /** The bots shared data for a conversation. This data is visible to every user within the conversation.  */
     conversationData?: any;
 
-    /** 
-     * The bots private data for a conversation.  This data is only visible to the given user within the conversation. 
-     * The session stores its session state using privateConversationData so it should always be persisted. 
+    /**
+     * The bots private data for a conversation.  This data is only visible to the given user within the conversation.
+     * The session stores its session state using privateConversationData so it should always be persisted.
      */
     privateConversationData?: any;
 }
@@ -1216,7 +1218,7 @@ export interface IBotStorageData {
 export interface IBotStorage {
     /** Reads in data from storage. */
     getData(context: IBotStorageContext, callback: (err: Error, data: IBotStorageData) => void): void;
-    
+
     /** Writes out data to storage. */
     saveData(context: IBotStorageContext, data: IBotStorageData, callback?: (err: Error) => void): void;
 }
@@ -1231,56 +1233,56 @@ export interface IChatConnectorSettings {
 
     /** If true the bots userData, privateConversationData, and conversationData will be gzipped prior to writing to storage. */
     gzipData?: boolean;
-    
+
     /** Collection of various necessary endpoints. Not normally provided by developers. */
     endpoint?: IChatConnectorEndpoint;
-        
+
     /** If not provided, stateEndpoint will default to https://state.botframework.com. */
     stateEndpoint?: string;
-    
+
     /** If not provided, openIdMetadata will default to https://login.botframework.com/v1/.well-known/openidconfiguration. */
     openIdMetadata?: string;
 }
-    
+
 /** Options used to set various endpoints in a ChatConnector instance. This should not be changed and is normally not provided by developers in IChatConnectorSettings. Instead the two properties in IChatConnectorSettings, "stateEndpoint," and "openIdMetadata" should be changed there.  */
 export interface IChatConnectorEndpoint {
-    
+
     /** Default value is https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token. */
     refreshEndpoint: string;
-    
+
     /** Default value is https://api.botframework.com/.default. */
     refreshScope: string;
-    
+
     /** Default value is https://login.botframework.com/v1/.well-known/openidconfiguration. Configurable via IChatConnectorSettings.openIdMetadata. */
     botConnectorOpenIdMetadata: string;
-    
+
     /** Default value is https://api.botframework.com. */
     botConnectorIssuer: string;
-    
+
     /** This value is provided via IChatConnectorSettings.appId. */
     botConnectorAudience: string;
-    
+
     /** Default value is https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration. */
     msaOpenIdMetadata: string;
-    
+
     /** Default value is https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/. */
     msaIssuer: string;
-    
+
     /** Default value is https://graph.microsoft.com. */
     msaAudience: string;
-    
+
     /** Default value is https://login.microsoftonline.com/botframework.com/v2.0/.well-known/openid-configuration. */
     emulatorOpenIdMetadata: string;
-    
+
     /** Default value is https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/. */
     emulatorIssuerV1: string;
-    
+
     /** Default value is https://login.microsoftonline.com/d6d49420-f39b-4df7-a1dc-d59a935871db/v2.0. */
     emulatorIssuerV2: string;
-    
+
     /** This value is provided via IChatConnectorSettings.appId. */
     emulatorAudience: string;
-    
+
     /** Default value is https://state.botframework.com. Configurable via IChatConnectorSettings.stateEndpoint. */
     stateEndpoint: string;
 }
@@ -1289,7 +1291,7 @@ export interface IChatConnectorEndpoint {
 export interface IUniversalBotSettings {
     /** (Optional) dialog to launch when a user initiates a new conversation with a bot. Default value is '/'. */
     defaultDialogId?: string;
-    
+
     /** (Optional) arguments to pass to the initial dialog for a conversation. */
     defaultDialogArgs?: any;
 
@@ -1298,7 +1300,7 @@ export interface IUniversalBotSettings {
 
     /** (Optional) function used to map the user ID for an incoming message to another user ID.  This can be used to implement user account linking. */
     lookupUser?: (address: IAddress, done: (err: Error, user: IIdentity) => void) => void;
-    
+
     /** (Optional) maximum number of async options to conduct in parallel. */
     processLimit?: number;
 
@@ -1320,46 +1322,46 @@ export interface IUniversalBotSettings {
 
 /** Implemented by connector plugins for the UniversalBot. */
 export interface IConnector {
-    /** 
+    /**
      * (Optional) Called by the UniversalBot at registration time to register a handler for
      * receiving incoming invoke events. Invoke events are special events which are expected to
-     * return a body inline as part of the response to the received request. 
+     * return a body inline as part of the response to the received request.
      * @param handler The function that should be called anytime an "invoke" event is received.
      */
     onInvoke?(handler: (event: IEvent, callback?: (err: Error, body: any, status?: number) => void) => void): void;
 
-    /** 
-     * Called by the UniversalBot at registration time to register a handler for receiving incoming 
-     * events from a channel. 
+    /**
+     * Called by the UniversalBot at registration time to register a handler for receiving incoming
+     * events from a channel.
      * @param handler The function that should be called anytime an event is received that is not of type "invoke".
      */
     onEvent(handler: (events: IEvent[], callback?: (err: Error) => void) => void): void;
 
-    /** 
+    /**
      * Sends outgoing message(s) to a user. This method will ultimately get called anytime you call
      * [UniversalBot.send()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.universalbot#send) or [Session.send()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session#send).
-     * 
-     * You can manually call this method using `session.connector.send()` as a convenient way of 
+     *
+     * You can manually call this method using `session.connector.send()` as a convenient way of
      * getting the address of the message that was sent. You can then store this address and use
      * it at a later point in time to either update or delete the message. The one thing to keep
-     * in mind is that if you manually call `session.connector.send()` you will bypass any 
-     * middleware that the outgoing message would normally run through. Calling 
+     * in mind is that if you manually call `session.connector.send()` you will bypass any
+     * middleware that the outgoing message would normally run through. Calling
      * `session.send(msg).sendBatch(function (err, addresses) { })` does the same thing but ensures
-     * that the outgoing message is sent through middleware.   
+     * that the outgoing message is sent through middleware.
      * @param messages Array of message(s) to send the user.
-     * @param callback Function to invoke once the operation is completed. 
+     * @param callback Function to invoke once the operation is completed.
      * @param callback.err Any error that occurred during the send.
      * @param callback.addresses An array of address objects returned for each individual message within the batch. These address objects contain the ID of the posted messages so can be used to update or delete a message in the future.
      */
     send(messages: IMessage[], callback: (err: Error, addresses?: IAddress[]) => void): void;
 
-    /** 
-     * Called when a UniversalBot wants to start a new proactive conversation with a user. The 
+    /**
+     * Called when a UniversalBot wants to start a new proactive conversation with a user. The
      * connector should return an address with a properly formated [IAddress.conversation](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iaddress#conversation)
-     * field. This will typically be called when you call [UniversalBot.beginDialog()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.universalbot#begindialog) 
-     * but will also be called anytime `IAddress.conversation` is null for a message being sent. 
+     * field. This will typically be called when you call [UniversalBot.beginDialog()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.universalbot#begindialog)
+     * but will also be called anytime `IAddress.conversation` is null for a message being sent.
      * @param address The address of the user to start the conversation for. The `IAddress.conversation` field should be null.
-     * @param callback Function to invoke once the operation is completed. 
+     * @param callback Function to invoke once the operation is completed.
      * @param callback.err Any error that occurred while attempting to start the conversation.
      * @param callback.address The address of the conversation that was started. This can be used to send future messages to the conversation.
      */
@@ -1368,16 +1370,16 @@ export interface IConnector {
     /**
      * (Optional) method that can be called to replace a message that was previously sent using [send()](#send).
      * @param message The message to overwrite an existing message with. The `message.address` field should contain an address returned from a previous call to [send()](#send).
-     * @param callback Function to invoke once the operation is completed. 
+     * @param callback Function to invoke once the operation is completed.
      * @param callback.err Any error that occurred while replacing the message.
-     * @param callback.address The address of the new message. For some channels this may different from the original messages address. 
+     * @param callback.address The address of the new message. For some channels this may different from the original messages address.
      */
     update?(message: IMessage, callback: (err: Error, address?: IAddress) => void): void;
 
-    /** 
+    /**
      * (Optional) method that can be called to delete a message that was previously sent using [send()](#send).
      * @param address The address of the message to delete.
-     * @param callback Function to invoke once the operation is completed. 
+     * @param callback Function to invoke once the operation is completed.
      * @param callback.err Any error that occurred while replacing the message.
      */
     delete?(address: IAddress, callback: (err: Error) => void): void;
@@ -1393,8 +1395,8 @@ export interface ISessionMiddleware {
     (session: Session, next: Function): void;
 }
 
-/** 
- * Map of middleware hooks that can be registered in a call to __UniversalBot.use()__. 
+/**
+ * Map of middleware hooks that can be registered in a call to __UniversalBot.use()__.
  */
 export interface IMiddlewareMap {
     /** Called in series when an incoming event is received. */
@@ -1407,39 +1409,39 @@ export interface IMiddlewareMap {
     botbuilder?: ISessionMiddleware|ISessionMiddleware[];
 }
 
-/** 
- * Signature for functions passed as steps to [DialogAction.waterfall()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.dialogaction.html#waterfall). 
- * 
+/**
+ * Signature for functions passed as steps to [DialogAction.waterfall()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.dialogaction.html#waterfall).
+ *
  * Waterfalls let you prompt a user for information using a sequence of questions. Each step of the
  * waterfall can either execute one of the built-in [Prompts](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.__global.iprompts.html),
  * start a new dialog by calling [session.beginDialog()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session.html#begindialog),
  * advance to the next step of the waterfall manually using `skip()`, or terminate the waterfall.
- * 
- * When either a dialog or built-in prompt is called from a waterfall step, the results from that 
- * dialog or prompt will be passed via the `results` parameter to the next step of the waterfall. 
+ *
+ * When either a dialog or built-in prompt is called from a waterfall step, the results from that
+ * dialog or prompt will be passed via the `results` parameter to the next step of the waterfall.
  * Users can say things like "never mind" to cancel the built-in prompts so you should guard against
- * that by at least checking for [results.response](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogresult.html#response) 
- * before proceeding. A more detailed explanation of why the waterfall is being continued can be 
- * determined by looking at the [code](/en-us/node/builder/chat-reference/enums/_botbuilder_d_.resumereason.html) 
+ * that by at least checking for [results.response](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogresult.html#response)
+ * before proceeding. A more detailed explanation of why the waterfall is being continued can be
+ * determined by looking at the [code](/en-us/node/builder/chat-reference/enums/_botbuilder_d_.resumereason.html)
  * returned for [results.resumed](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogresult.html#resumed).
- * 
+ *
  * You can manually advance to the next step of the waterfall using the `skip()` function passed
  * in. Calling `skip({ response: "some text" })` with an [IDialogResult](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogresult.html)
  * lets you more accurately mimic the results from a built-in prompt and can simplify your overall
  * waterfall logic.
- * 
+ *
  * You can terminate a waterfall early by either falling through every step of the waterfall using
  * calls to `skip()` or simply not starting another prompt or dialog.
- * 
- * __note:__ Waterfalls have a hidden last step which will automatically end the current dialog if 
+ *
+ * __note:__ Waterfalls have a hidden last step which will automatically end the current dialog if
  * if you call a prompt or dialog from the last step. This is useful where you have a deep stack of
  * dialogs and want a call to [session.endDialog()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session.html#enddialog)
  * from the last child on the stack to end the entire stack. The close of the last child will trigger
  * all of its parents to move to this hidden step which will cascade the close all the way up the stack.
- * This is typically a desired behavior but if you want to avoid it or stop it somewhere in the 
- * middle you'll need to add a step to the end of your waterfall that either does nothing or calls 
+ * This is typically a desired behavior but if you want to avoid it or stop it somewhere in the
+ * middle you'll need to add a step to the end of your waterfall that either does nothing or calls
  * something like [session.send()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session.html#send)
- * which isn't going to advance the waterfall forward.   
+ * which isn't going to advance the waterfall forward.
  * @example
  * <pre><code>
  * var bot = new builder.BotConnectorBot();
@@ -1462,10 +1464,10 @@ export interface IMiddlewareMap {
 export interface IDialogWaterfallStep {
     /**
      * @param session Session object for the current conversation.
-     * @param result 
+     * @param result
      * * __result:__ _{any}_ - For the first step of the waterfall this will be `null` or the value of any arguments passed to the handler.
      * * __result:__ _{IDialogResult}_ - For subsequent waterfall steps this will be the result of the prompt or dialog called in the previous step.
-     * @param skip Function used to manually skip to the next step of the waterfall.  
+     * @param skip Function used to manually skip to the next step of the waterfall.
      * @param skip.results (Optional) results to pass to the next waterfall step. This lets you more accurately mimic the results returned from a prompt or dialog.
      */
     (session: Session, result?: any | IDialogResult<any>, skip?: (results?: IDialogResult<any>) => void): any;
@@ -1568,31 +1570,31 @@ export interface IAnimationCard extends IMediaCard {
 /** Interface definition of a generic MediaCard, which in its concrete form can be an Audio, Animation or Video card */
 export interface IMediaCard {
     /** Title of the Card */
-    title: string; 
+    title: string;
 
     /** Subtitle appears just below Title field, differs from Title in font styling only */
-    subtitle: string; 
+    subtitle: string;
 
-    /** Text field appears just below subtitle, differs from Subtitle in font styling only */ 
-    text: string; 
+    /** Text field appears just below subtitle, differs from Subtitle in font styling only */
+    text: string;
 
-    /** Messaging supports all media formats: audio, video, images and thumbnails as well to optimize content download.*/ 
+    /** Messaging supports all media formats: audio, video, images and thumbnails as well to optimize content download.*/
     image: ICardImage;
 
     /** Media source for video, audio or animations */
     media: ICardMediaUrl[];
 
     /** Set of actions applicable to the current card */
-    buttons?: ICardAction[]; 
+    buttons?: ICardAction[];
 
     /** Should the media source reproduction run in a loop */
-    autoloop: boolean; 
-    
+    autoloop: boolean;
+
     /** Should the media start automatically */
     autostart: boolean;
-    
+
     /** Should media be shareable */
-    shareable: boolean; 
+    shareable: boolean;
 
     /** Supplementary parameter for this card. */
     value: any;
@@ -1602,7 +1604,7 @@ export interface IMediaCard {
 export interface ICardMediaUrl {
 
     /** Url to audio, video or animation media */
-    url: string; 
+    url: string;
 
     /** Optional profile hint to the client to differentiate multiple MediaUrl objects from each other */
     profile: string ;
@@ -1642,24 +1644,24 @@ export enum ResumeReason {
 }
 
 /** Order in which an [IntentDialogs](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.intentdialog.html) recognizers should be evaluated. */
-export enum RecognizeOrder { 
+export enum RecognizeOrder {
     /** All recognizers will be evaluated in parallel. */
     parallel,
 
     /** Recognizers will be evaluated in series. Any recognizer that returns a score of 1.0 will prevent the evaluation of the remaining recognizers. */
-    series 
+    series
 }
 
 /** Controls an [IntentDialogs](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.intentdialog.html) processing of the users text utterances. */
-export enum RecognizeMode { 
+export enum RecognizeMode {
     /** Process text utterances whenever the dialog is first loaded through a call to session.beginDialog() and anytime a reply from the user is received. This was the default behaviour prior to version 3.2. */
-    onBegin, 
+    onBegin,
 
     /** Processes text utterances anytime a reply is received but only when the dialog is first loaded if it's the root dialog. This is the default behaviour as of 3.2. */
-    onBeginIfRoot, 
+    onBeginIfRoot,
 
     /** Only process text utterances when a reply is received. */
-    onReply 
+    onReply
 }
 
 /**
@@ -1686,19 +1688,19 @@ export enum PromptType {
 }
 
 /** Type of list to render for PromptType.choice prompt. */
-export enum ListStyle { 
+export enum ListStyle {
     /** No list is rendered. This is used when the list is included as part of the prompt. */
-    none, 
-    
+    none,
+
     /** Choices are rendered as an inline list of the form "1. red, 2. green, or 3. blue". */
-    inline, 
-    
+    inline,
+
     /** Choices are rendered as a numbered list. */
     list,
-    
+
     /** Choices are rendered as buttons for channels that support buttons. For other channels they will be rendered as text. */
     button,
-    
+
     /** The style is selected automatically based on the channel and number of options. */
     auto
 }
@@ -1717,7 +1719,7 @@ export var TextFormat: {
 
 /** Identities how the client should render attachments for a message. */
 export var AttachmentLayout: {
-    /** Attachments should be rendred as a list. */    
+    /** Attachments should be rendred as a list. */
     list: string;
 
     /** Attachments should be rendered as a carousel. */
@@ -1726,12 +1728,12 @@ export var AttachmentLayout: {
 
 /** Indicates whether the bot is accepting, expecting, or ignoring input. */
 export var InputHint: {
-    /** The sender is passively ready for input but is not waiting on a response. */    
+    /** The sender is passively ready for input but is not waiting on a response. */
     acceptingInput: string;
 
-    /** 
-     * The sender is ignoring input. Bots may send this hint if they are actively 
-     * processing a request and will ignore input from users until the request is 
+    /**
+     * The sender is ignoring input. Bots may send this hint if they are actively
+     * processing a request and will ignore input from users until the request is
      * complete.
      */
     ignoringInput: string;
@@ -1772,8 +1774,8 @@ export class Session {
     /**
      * Finalizes the initialization of the session object and then routes the session through all
      * installed middleware. The passed in `next()` function will be called as the last step of the
-     * middleware chain. 
-     * @param sessionState The current session state. If `null` a new conversation will be started beginning with the configured [dialogId](#dialogid).  
+     * middleware chain.
+     * @param sessionState The current session state. If `null` a new conversation will be started beginning with the configured [dialogId](#dialogid).
      * @param message The message to route through middleware.
      * @param next The function to invoke as the last step of the middleware chain.
      */
@@ -1793,10 +1795,10 @@ export class Session {
 
     /** Data for the user that's persisted across all conversations with the bot. */
     userData: any;
-    
+
     /** Shared conversation data that's visible to all members of the conversation. */
     conversationData: any;
-    
+
     /** Private conversation data that's only visible to the user. */
     privateConversationData: any;
 
@@ -1804,8 +1806,8 @@ export class Session {
     dialogData: any;
 
     /** The localizer for the current session. */
-    localizer: ILocalizer ;    
-    
+    localizer: ILocalizer ;
+
     /**
      * Signals that an error occured. The bot will signal the error via an on('error', err) event.
      * @param err Error that occured.
@@ -1822,10 +1824,10 @@ export class Session {
      */
     error(err: Error): Session;
 
-    /** 
+    /**
      * Returns the preferred locale when no parameters are supplied, otherwise sets the preferred locale.
-     * @param locale (Optional) the locale to use for localizing messages. 
-     * @param callback (Optional) function called when the localization table has been loaded for the supplied locale. 
+     * @param locale (Optional) the locale to use for localizing messages.
+     * @param callback (Optional) function called when the localization table has been loaded for the supplied locale.
      * @example
      * <pre><code>
      * bot.dialog('localePicker', [
@@ -1848,9 +1850,9 @@ export class Session {
 
     /**
      * Loads a localized string for the messages language. If arguments are passed the localized string
-     * will be treated as a template and formatted using [sprintf-js](https://github.com/alexei/sprintf.js) (see their docs for details.) 
+     * will be treated as a template and formatted using [sprintf-js](https://github.com/alexei/sprintf.js) (see their docs for details.)
      * @param msgid String to use as a key in the localized string table. Typically this will just be the english version of the string.
-     * @param args (Optional) arguments used to format the final output string. 
+     * @param args (Optional) arguments used to format the final output string.
      * @example
      * <pre><code>
      * var msg = session.gettext("")
@@ -1859,7 +1861,7 @@ export class Session {
     gettext(msgid: string, ...args: any[]): string;
 
     /**
-     * Loads the plural form of a localized string for the messages language. The output string will be formatted to 
+     * Loads the plural form of a localized string for the messages language. The output string will be formatted to
      * include the count by replacing %d in the string with the count.
      * @param msgid Singular form of the string to use as a key in the localized string table. Use %d to specify where the count should go.
      * @param msgid_plural Plural form of the string to use as a key in the localized string table. Use %d to specify where the count should go.
@@ -1871,14 +1873,14 @@ export class Session {
     save(): Session;
 
     /**
-     * Sends a message to the user. 
+     * Sends a message to the user.
      * @param message Text/message to send to user. If an array is passed a response will be chosen at random.
      * @param args (Optional) arguments used to format the final output text when __message__ is a _{string|string[]}_.
      */
     send(message: TextOrMessageType, ...args: any[]): Session;
 
     /**
-     * Sends a message to a user using a specific localization namespace. 
+     * Sends a message to a user using a specific localization namespace.
      * @param libraryNamespace Namespace to use for localizing the message.
      * @param message Text/message to send to user.
      * @param args (Optional) arguments used to format the final output text when __message__ is a _{string|string[]}_.
@@ -1886,9 +1888,9 @@ export class Session {
     sendLocalized(libraryNamespace: string, message: TextOrMessageType, ...args: any[]): Session;
 
     /**
-     * Sends a text, and optional SSML, message to the user. 
-     * @param text Text to send to the user. This can be null to send only SSML or attachments. 
-     * @param speak (Optional) message that should be spoken to the user. The message should be formatted as [Speech Synthesis Markup Language (SSML)](https://msdn.microsoft.com/en-us/library/hh378377(v=office.14).aspx). 
+     * Sends a text, and optional SSML, message to the user.
+     * @param text Text to send to the user. This can be null to send only SSML or attachments.
+     * @param speak (Optional) message that should be spoken to the user. The message should be formatted as [Speech Synthesis Markup Language (SSML)](https://msdn.microsoft.com/en-us/library/hh378377(v=office.14).aspx).
      * If an array is passed a response will be chosen at random.
      * @param options (Optional) properties that should be included on the outgoing message.
      */
@@ -1896,17 +1898,17 @@ export class Session {
     say(text: TextType, options?: IMessageOptions): Session;
 
     /**
-     * Sends a text, and optional SSML, message to the user using a specific localization namespace. 
+     * Sends a text, and optional SSML, message to the user using a specific localization namespace.
      * @param libraryNamespace Namespace to use for localizing the message.
-     * @param text Text to send to the user. This can be null to send only SSML or attachments. 
-     * @param speak (Optional) message that should be spoken to the user. The message should be formatted as [Speech Synthesis Markup Language (SSML)](https://msdn.microsoft.com/en-us/library/hh378377(v=office.14).aspx). 
+     * @param text Text to send to the user. This can be null to send only SSML or attachments.
+     * @param speak (Optional) message that should be spoken to the user. The message should be formatted as [Speech Synthesis Markup Language (SSML)](https://msdn.microsoft.com/en-us/library/hh378377(v=office.14).aspx).
      * If an array is passed a response will be chosen at random.
      * @param options (Optional) properties that should be included on the outgoing message.
      */
     sayLocalized(libraryNamespace: string, text: TextType, speak?: TextType, options?: IMessageOptions): Session;
 
     /**
-     * Sends the user an indication that the bot is typing. For long running operations this should be called every few seconds. 
+     * Sends the user an indication that the bot is typing. For long running operations this should be called every few seconds.
      */
     sendTyping(): Session;
 
@@ -1922,33 +1924,33 @@ export class Session {
     messageSent(): boolean;
 
     /**
-     * Passes control of the conversation to a new dialog. The current dialog will be suspended 
+     * Passes control of the conversation to a new dialog. The current dialog will be suspended
      * until the child dialog completes. Once the child ends the current dialog will receive a
-     * call to [dialogResumed()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.dialog.html#dialogresumed) 
-     * where it can inspect any results returned from the child. 
+     * call to [dialogResumed()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.dialog.html#dialogresumed)
+     * where it can inspect any results returned from the child.
      * @param id Unique ID of the dialog to start.
      * @param args (Optional) arguments to pass to the dialogs [begin()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.dialog.html#begin) method.
      */
     beginDialog<T>(id: string, args?: T): Session;
 
     /**
-     * Ends the current dialog and starts a new one its place. The parent dialog will not be 
-     * resumed until the new dialog completes. 
+     * Ends the current dialog and starts a new one its place. The parent dialog will not be
+     * resumed until the new dialog completes.
      * @param id Unique ID of the dialog to start.
      * @param args (Optional) arguments to pass to the dialogs [begin()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.dialog.html#begin) method.
      */
     replaceDialog<T>(id: string, args?: T): Session;
 
-    /** 
-     * Ends the current conversation and optionally sends a message to the user. 
+    /**
+     * Ends the current conversation and optionally sends a message to the user.
      * @param message (Optional) text/message to send the user before ending the conversation.
      * @param args (Optional) arguments used to format the final output text when __message__ is a _{string|string[]}_.
      */
     endConversation(message?: TextOrMessageType, ...args: any[]): Session;
 
     /**
-     * Ends the current dialog and optionally sends a message to the user. The parent will be resumed with an [IDialogResult.resumed](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogresult.html#resumed) 
-     * reason of [completed](/en-us/node/builder/chat-reference/enums/_botbuilder_d_.resumereason.html#completed).  
+     * Ends the current dialog and optionally sends a message to the user. The parent will be resumed with an [IDialogResult.resumed](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogresult.html#resumed)
+     * reason of [completed](/en-us/node/builder/chat-reference/enums/_botbuilder_d_.resumereason.html#completed).
      * @param message (Optional) text/message to send the user before ending the dialog.
      * @param args (Optional) arguments used to format the final output text when __message__ is a _{string|string[]}_.
      */
@@ -1956,17 +1958,17 @@ export class Session {
 
     /**
      * Ends the current dialog and optionally returns a result to the dialogs parent.
-     * @param result (Optional) result to send the user. The value you'd like to return should be in the [response](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogresult#response) field.  
+     * @param result (Optional) result to send the user. The value you'd like to return should be in the [response](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogresult#response) field.
      */
     endDialogWithResult(result?: IDialogResult<any>): Session;
-    
-    /** 
+
+    /**
      * Cancels an existing dialog and optionally starts a new one it its place.  Unlike [endDialog()](#enddialog)
-     * and [replaceDialog()](#replacedialog) which affect the current dialog, this method lets you end a 
-     * parent dialog anywhere on the stack. The parent of the canceled dialog will be continued as if the 
-     * dialog had called endDialog(). A special [ResumeReason.canceled](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.resumereason#canceled) 
-     * will be returned to indicate that the dialog was canceled. 
-     * @param dialogId 
+     * and [replaceDialog()](#replacedialog) which affect the current dialog, this method lets you end a
+     * parent dialog anywhere on the stack. The parent of the canceled dialog will be continued as if the
+     * dialog had called endDialog(). A special [ResumeReason.canceled](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.resumereason#canceled)
+     * will be returned to indicate that the dialog was canceled.
+     * @param dialogId
      * * __dialogId:__ _{string}_ - ID of the dialog to end. If multiple occurences of the dialog exist on the dialog stack, the last occurance will be canceled.
      * * __dialogId:__ _{number}_ - Index of the dialog on the stack to cancel. This is the preferred way to cancel a dialog from an action handler as it ensures that the correct instance is canceled.
      * @param replaceWithId (Optional) specifies an ID to start in the canceled dialogs place. This prevents the dialogs parent from being resumed.
@@ -1984,19 +1986,19 @@ export class Session {
     /** Returns true if the session has been reset. */
     isReset(): boolean;
 
-    /** 
+    /**
      * Immediately ends the current batch and delivers any queued up messages.
-     * @param done (Optional) function called when the batch was either successfully delievered or failed for some reason. 
+     * @param done (Optional) function called when the batch was either successfully delievered or failed for some reason.
      * @param done.err Any error that occured during the send.
      * @param done.addresses An array of address objects returned for each individual message within the batch. These address objects contain the ID of the posted messages so can be used to update or delete a message in the future.
      */
     sendBatch(done?: (err: Error, addresses?: IAddress[]) => void): void;
 
     /**
-     * Gets/sets the current dialog stack. A copy of the current dialog is returned so if any 
-     * changes are made to the returned stack they will need to be copied back to the session 
+     * Gets/sets the current dialog stack. A copy of the current dialog is returned so if any
+     * changes are made to the returned stack they will need to be copied back to the session
      * via a second call to `session.dialogStack()`.
-     * @param newStack (Optional) dialog stack to assign to session. The sessions [dialogData](#dialogdata) will be updated to reflect the state of the new active dialog. 
+     * @param newStack (Optional) dialog stack to assign to session. The sessions [dialogData](#dialogdata) will be updated to reflect the state of the new active dialog.
      */
     dialogStack(newStack?: IDialogState[]): IDialogState[];
 
@@ -2021,8 +2023,8 @@ export class Session {
      */
     static forEachDialogStackEntry(stack: IDialogState[], reverse: boolean, fn: (entry: IDialogState, index: number) => void): void;
 
-    /** 
-     * Searches a dialog stack for a specific dialog, in either a forward or reverse direction, 
+    /**
+     * Searches a dialog stack for a specific dialog, in either a forward or reverse direction,
      * returning its index.
      * @param stack The dialog stack to search.
      * @param dialogId The unique ID of the dialog, in `<namespace>:<dialog>` format, to search for.
@@ -2030,36 +2032,36 @@ export class Session {
      */
     static findDialogStackEntry(stack: IDialogState[], dialogId: string, reverse?: boolean): number;
 
-    /** 
-     * Returns a stacks active dialog or null. 
+    /**
+     * Returns a stacks active dialog or null.
      * @param stack The dialog stack to return the entry for.
      */
     static activeDialogStackEntry(stack: IDialogState[]): IDialogState;
 
-    /** 
-     * Pushes a new dialog onto a stack and returns it as the active dialog. 
+    /**
+     * Pushes a new dialog onto a stack and returns it as the active dialog.
      * @param stack The dialog stack to update.
      * @param entry Dialog entry to push onto the stack.
      */
     static pushDialogStackEntry(stack: IDialogState[], entry: IDialogState): IDialogState;
-    
-    /** 
-     * Pops the active dialog off a stack and returns the new one if the stack isn't empty.  
+
+    /**
+     * Pops the active dialog off a stack and returns the new one if the stack isn't empty.
      * @param stack The dialog stack to update.
      */
     static popDialogStackEntry(stack: IDialogState[]): IDialogState;
 
-    /** 
-     * Deletes all dialog stack entries starting with the specified index and returns the new 
-     * active dialog. 
+    /**
+     * Deletes all dialog stack entries starting with the specified index and returns the new
+     * active dialog.
      * @param stack The dialog stack to update.
      * @param start Index of the first element to remove.
      */
     static pruneDialogStack(stack: IDialogState[], start: number): IDialogState;
-    
-    /** 
-     * Ensures that all of the entries on a dialog stack reference valid dialogs within a library 
-     * hierarchy. 
+
+    /**
+     * Ensures that all of the entries on a dialog stack reference valid dialogs within a library
+     * hierarchy.
      * @param stack The dialog stack to validate.
      * @param root The root of the library hierarchy, typically the bot.
      */
@@ -2080,7 +2082,7 @@ export class Session {
     /**
      * Adds or retrieves a variable that can be watched.
      * @param variable Name of the variable that can be watched. Case is used for display only.
-     * @param handler (Optional) Function used to retrieve the variables current value. If specified a new handler will be registered, otherwise the existing handler will be retrieved. 
+     * @param handler (Optional) Function used to retrieve the variables current value. If specified a new handler will be registered, otherwise the existing handler will be retrieved.
      */
     static watchable(variable: string, handler?: IWatchableHandler): IWatchableHandler;
 
@@ -2137,13 +2139,13 @@ export class SessionLogger {
 /**
  * Logs session activity to a remote endpoint using debug events. The remote debugger
  * is automatically used when the emulator connects to your bot. Non-emulator channels
- * can stream their activity to the emulator by saving the address of the emulator 
+ * can stream their activity to the emulator by saving the address of the emulator
  * session to `session.privateConversationData["BotBuilder.Data.DebugSession"]`.
  */
 export class RemoteSessionLogger extends SessionLogger {
     /**
      * Creates an instance of the remote session logger.
-     * @param connector Connector used to communicate with the remote endpoint. 
+     * @param connector Connector used to communicate with the remote endpoint.
      * @param address Address to deliver debug events to.
      * @param relatesTo Address of the conversation the debug events are for.
      */
@@ -2157,9 +2159,9 @@ export class Message implements IIsMessage {
     /** Internal message object being built. */
     protected data: IMessage;
 
-    /** 
-     * Creates a new Message builder. 
-     * @param session (Optional) will be used to populate the messages address and localize any text. 
+    /**
+     * Creates a new Message builder.
+     * @param session (Optional) will be used to populate the messages address and localize any text.
      */
     constructor(session?: Session);
 
@@ -2171,54 +2173,54 @@ export class Message implements IIsMessage {
 
     /** Conditionally set the speak field of the message given a specified count. */
     nspeak(ssml: TextType, ssml_plural: TextType, count: number): Message;
-    
-    /** Language of the message. */   
+
+    /** Language of the message. */
     textLocale(locale: string): Message;
 
     /** Format of text fields. */
     textFormat(style: string): Message;
-    
+
     /** Sets the message text. */
     text(text: TextType, ...args: any[]): Message;
-    
+
     /** Conditionally set the message text given a specified count. */
     ntext(msg: TextType, msg_plural: TextType, count: number): Message;
-    
+
     /** Composes a complex and randomized reply to the user.  */
     compose(prompts: string[][], ...args: any[]): Message;
 
-    /** Text to be displayed by as fall-back and as short description of the message content in e.g. list of recent conversations. */  
+    /** Text to be displayed by as fall-back and as short description of the message content in e.g. list of recent conversations. */
     summary(text: TextType, ...args: any[]): Message;
 
-    /** Hint for how clients should layout multiple attachments. The default value is 'list'. */ 
+    /** Hint for how clients should layout multiple attachments. The default value is 'list'. */
     attachmentLayout(style: string): Message;
-    
+
     /** Cards or images to send to the user. */
     attachments(list: AttachmentType[]): Message;
-       
+
     /**
      * Adds an attachment to the message. See [IAttachment](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iattachment.html) for examples.
-     * @param attachment The attachment to add.   
-     */    
+     * @param attachment The attachment to add.
+     */
     addAttachment(attachment: AttachmentType): Message;
-    
+
     /** Optional suggested actions to send to the user. Suggested actions will be displayed only on the channels that support suggested actions. */
     suggestedActions(suggestedActions: ISuggestedActions|IIsSuggestedActions): Message;
 
     /** Structured objects passed to the bot or user. */
     entities(list: Object[]): Message;
-    
+
     /** Adds an entity to the message. */
     addEntity(obj: Object): Message;
-    
+
     /** Address routing information for the message. Save this field to external storage somewhere to later compose a proactive message to the user. */
     address(adr: IAddress): Message;
-    
+
     /** Set by connectors service. Use [localTimestamp()](#localtimestamp) instead. */
     timestamp(time?: string): Message;
 
-    /** 
-     * Local time when message was sent (set by client or bot, Ex: 2016-09-23T13:07:49.4714686-07:00.) 
+    /**
+     * Local time when message was sent (set by client or bot, Ex: 2016-09-23T13:07:49.4714686-07:00.)
      * @param time (Optional) time expressed as an ISO string. Defaults to `new Date().toISOString()`.
      */
     localTimestamp(time?: string): Message;
@@ -2226,7 +2228,7 @@ export class Message implements IIsMessage {
     /** Message in original/native format of the channel for incoming messages. */
     originalEvent(event: any): Message;
 
-    /** For outgoing messages can be used to pass source specific event data like custom attachments. */  
+    /** For outgoing messages can be used to pass source specific event data like custom attachments. */
     sourceEvent(map: ISourceEventMap): Message;
 
     /** Open-ended value. */
@@ -2241,37 +2243,37 @@ export class Message implements IIsMessage {
     /** Code indicating why the conversation has ended. */
     code(value: string): Message;
 
-    /** Returns the JSON for the message. */    
+    /** Returns the JSON for the message. */
     toMessage(): IMessage;
 
     /** __DEPRECATED__ use [local()](#local) instead. */
     setLanguage(language: string): Message;
-    
-    /** __DEPRECATED__ use [text()](#text) instead. */ 
+
+    /** __DEPRECATED__ use [text()](#text) instead. */
     setText(session: Session, prompt: TextType, ...args: any[]): Message;
 
-    /** __DEPRECATED__ use [ntext()](#ntext) instead. */ 
+    /** __DEPRECATED__ use [ntext()](#ntext) instead. */
     setNText(session: Session, msg: string, msg_plural: string, count: number): Message;
 
-    /** __DEPRECATED__ use [compose()](#compose) instead. */ 
+    /** __DEPRECATED__ use [compose()](#compose) instead. */
     composePrompt(session: Session, prompts: string[][], ...args: any[]): Message;
-    
-    /** __DEPRECATED__ use [sourceEvent()](#sourceevent) instead. */ 
+
+    /** __DEPRECATED__ use [sourceEvent()](#sourceevent) instead. */
     setChannelData(data: any): Message;
-    
+
     /**
      * Selects a prompt at random.
      * @param prompts Array of prompts to choose from. When prompts is type _string_ the prompt will simply be returned unmodified.
      */
     static randomPrompt(prompts: TextType): string;
-    
+
     /**
      * Combines an array of prompts into a single localized prompt and then optionally fills the
-     * prompts template slots with the passed in arguments. 
+     * prompts template slots with the passed in arguments.
      * @param session Session object used to localize the individual prompt parts.
-     * @param prompts Array of prompt lists. Each entry in the array is another array of prompts 
+     * @param prompts Array of prompt lists. Each entry in the array is another array of prompts
      *                which will be chosen at random.  The combined output text will be space delimited.
-     * @param args (Optional) array of arguments used to format the output text when the prompt is a template.  
+     * @param args (Optional) array of arguments used to format the output text when the prompt is a template.
      */
     static composePrompt(session: Session, prompts: string[][], args?: any[]): string;
 }
@@ -2279,21 +2281,21 @@ export class Message implements IIsMessage {
 /** Builder class to simplify adding actions to a card. */
 export class CardAction implements IIsCardAction {
 
-    /** 
-     * Creates a new CardAction. 
-     * @param session (Optional) will be used to localize any text. 
+    /**
+     * Creates a new CardAction.
+     * @param session (Optional) will be used to localize any text.
      */
     constructor(session?: Session);
-    
+
     /** Type of card action. */
     type(t: string): CardAction;
-    
+
     /** Title of the action. For buttons this will be the label of the button.  For tap actions this may be used for accesibility purposes or shown on hover. */
     title(text: TextType, ...args: any[]): CardAction;
 
-    /** The actions value. */    
+    /** The actions value. */
     value(v: string): CardAction;
-    
+
     /** For buttons an image to include next to the buttons label. Not supported by all channels. */
     image(url: string): CardAction;
 
@@ -2303,75 +2305,75 @@ export class CardAction implements IIsCardAction {
     /** (Optional) text to display in the chat feed if the button is clicked. */
     displayText(text: TextType, ...args: any[]): CardAction;
 
-    /** Returns the JSON for the action. */    
+    /** Returns the JSON for the action. */
     toAction(): ICardAction;
 
-    /** 
-     * Places a call to a phone number. The should include country code in +44/+1 format for Skype calls. 
+    /**
+     * Places a call to a phone number. The should include country code in +44/+1 format for Skype calls.
      * @param session (Optional) Current session object for the conversation. If specified will be used to localize titles.
      */
     static call(session: Session, number: string, title?: TextType): CardAction;
-    
-    /** 
-     * Opens the specified URL. 
+
+    /**
+     * Opens the specified URL.
      * @param session (Optional) Current session object for the conversation. If specified will be used to localize titles.
      */
     static openUrl(session: Session, url: string, title?: TextType): CardAction;
-    
-    /** 
-     * Sends a message to the bot for processing in a way that's visible to all members of the conversation. For some channels this may get mapped to a [postBack](#postback). 
+
+    /**
+     * Sends a message to the bot for processing in a way that's visible to all members of the conversation. For some channels this may get mapped to a [postBack](#postback).
      * @param session (Optional) Current session object for the conversation. If specified will be used to localize titles.
      */
     static imBack(session: Session, msg: string, title?: TextType): CardAction;
-    
-    /** 
-     * Sends a message to the bot for processing in a way that's hidden from all members of the conversation. For some channels this may get mapped to a [imBack](#imback). 
+
+    /**
+     * Sends a message to the bot for processing in a way that's hidden from all members of the conversation. For some channels this may get mapped to a [imBack](#imback).
      * @param session (Optional) Current session object for the conversation. If specified will be used to localize titles.
      */
     static postBack(session: Session, msg: string, title?: TextType): CardAction;
-    
-    /** 
-     * Plays the specified audio file to the user. Not currently supported for Skype. 
+
+    /**
+     * Plays the specified audio file to the user. Not currently supported for Skype.
      * @param session (Optional) Current session object for the conversation. If specified will be used to localize titles.
      */
     static playAudio(session: Session, url: string, title?: TextType): CardAction;
-    
-    /** 
-     * Plays the specified video to the user. Not currently supported for Skype. 
+
+    /**
+     * Plays the specified video to the user. Not currently supported for Skype.
      * @param session (Optional) Current session object for the conversation. If specified will be used to localize titles.
      */
     static playVideo(session: Session, url: string, title?: TextType): CardAction;
-    
+
     /**
-     * Opens the specified image in a native image viewer. For Skype only valid as a tap action on a CardImage. 
+     * Opens the specified image in a native image viewer. For Skype only valid as a tap action on a CardImage.
      * @param session (Optional) Current session object for the conversation. If specified will be used to localize titles.
      */
     static showImage(session: Session, url: string, title?: TextType): CardAction;
-    
-    /** 
-     * Downloads the specified file to the users device. Not currently supported for Skype. 
+
+    /**
+     * Downloads the specified file to the users device. Not currently supported for Skype.
      * @param session (Optional) Current session object for the conversation. If specified will be used to localize titles.
      */
     static downloadFile(session: Session, url: string, title?: TextType): CardAction;
 
     /**
      * Binds a button or tap action to a named action registered for a dialog or globally off the bot.
-     * 
-     * Can be used anywhere a [postBack](#postback) is valid. You may also statically bind a button 
+     *
+     * Can be used anywhere a [postBack](#postback) is valid. You may also statically bind a button
      * to an action for something like Facebooks [Persistent Menus](https://developers.facebook.com/docs/messenger-platform/thread-settings/persistent-menu).
-     * The payload for the button should be `action?<action>` for actions without data or 
+     * The payload for the button should be `action?<action>` for actions without data or
      * `action?<action>=<data>` for actions with data.
      * @param session (Optional) Current session object for the conversation. If specified will be used to localize titles.
      * @param action Name of the action to invoke when tapped.
-     * @param data (Optional) data to pass to the action when invoked. The [IRecognizeActionResult.data](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.irecognizeactionresult#data) 
+     * @param data (Optional) data to pass to the action when invoked. The [IRecognizeActionResult.data](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.irecognizeactionresult#data)
      * property can be used to access this data. If using [beginDialogAction()](dlg./en-us/node/builder/chat-reference/classes/_botbuilder_d_.dialog#begindialogaction) this value will be passed
      * as part of the dialogs initial arguments.
-     * @param title (Optional) title to assign when binding the action to a button.  
+     * @param title (Optional) title to assign when binding the action to a button.
      */
     static dialogAction(session: Session, action: string, data?: string, title?: TextType): CardAction;
 
-    /** 
-     * Sends a message to the bot for processing. A `messageBack` has the ability to act like both an [imBack](#imback) and a [postBack](#postBack). 
+    /**
+     * Sends a message to the bot for processing. A `messageBack` has the ability to act like both an [imBack](#imback) and a [postBack](#postBack).
      * @param session (Optional) Current session object for the conversation. If specified will be used to localize titles.
      */
     static messageBack(session: Session, msg: string, title?: TextType): CardAction;
@@ -2404,21 +2406,21 @@ export class SuggestedActions implements IIsSuggestedActions {
 /** Builder class to simplify adding images to a card. */
 export class CardImage implements IIsCardImage {
 
-    /** 
-     * Creates a new CardImage. 
-     * @param session (Optional) will be used to localize any text. 
+    /**
+     * Creates a new CardImage.
+     * @param session (Optional) will be used to localize any text.
      */
     constructor(session?: Session);
-    
+
     /** URL of the image to display. */
     url(u: string): CardImage;
-    
+
     /** Alternate text of the image to use for accessibility pourposes. */
     alt(text: TextType, ...args: any[]): CardImage;
-    
+
     /** Action to take when the image is tapped. */
     tap(action: ICardAction|IIsCardAction): CardImage;
-    
+
     /** Returns the JSON for the image. */
     toImage(): ICardImage;
 
@@ -2429,16 +2431,16 @@ export class CardImage implements IIsCardImage {
 /** Card builder class that simplifies building keyboard cards. */
 export class Keyboard implements IIsAttachment {
 
-    /** 
-     * Creates a new ThumbnailCard. 
-     * @param session (Optional) will be used to localize any text. 
+    /**
+     * Creates a new ThumbnailCard.
+     * @param session (Optional) will be used to localize any text.
      */
     constructor(session?: Session);
 
     /** Session object for the current conversation. */
     protected session?: Session;
 
-    /** Set of actions applicable to the current card. Not all channels support buttons or cards with buttons. Some channels may choose to render the buttons using a custom keyboard. */  
+    /** Set of actions applicable to the current card. Not all channels support buttons or cards with buttons. Some channels may choose to render the buttons using a custom keyboard. */
     buttons(list: ICardAction[]|IIsCardAction[]): ThumbnailCard;
 
     /** Returns the JSON for the card */
@@ -2448,34 +2450,34 @@ export class Keyboard implements IIsAttachment {
 /** Card builder class that simplifies building thumbnail cards. */
 export class ThumbnailCard extends Keyboard {
 
-    /** 
-     * Creates a new ThumbnailCard. 
-     * @param session (Optional) will be used to localize any text. 
+    /**
+     * Creates a new ThumbnailCard.
+     * @param session (Optional) will be used to localize any text.
      */
     constructor(session?: Session);
-    
+
     /** Title of the Card. */
     title(text: TextType, ...args: any[]): ThumbnailCard;
 
-    /** Subtitle appears just below Title field, differs from Title in font styling only. */  
+    /** Subtitle appears just below Title field, differs from Title in font styling only. */
     subtitle(text: TextType, ...args: any[]): ThumbnailCard;
-    
+
     /** Text field appears just below subtitle, differs from Subtitle in font styling only. */
     text(text: TextType, ...args: any[]): ThumbnailCard;
-    
-    /** Messaging supports all media formats: audio, video, images and thumbnails as well to optimize content download. */  
+
+    /** Messaging supports all media formats: audio, video, images and thumbnails as well to optimize content download. */
     images(list: ICardImage[]|IIsCardImage[]): ThumbnailCard;
-    
-    /** This action will be activated when user taps on the card. Not all channels support tap actions and some channels may choose to render the tap action as the titles link. */  
+
+    /** This action will be activated when user taps on the card. Not all channels support tap actions and some channels may choose to render the tap action as the titles link. */
     tap(action: ICardAction|IIsCardAction): ThumbnailCard;
 }
 
 /** Card builder class that simplifies building Video cards. */
 export class VideoCard extends MediaCard implements IIsAttachment {
-    
-    /** 
-     * Creates a new VideoCard. 
-     * @param session (Optional) will be used to localize any text. 
+
+    /**
+     * Creates a new VideoCard.
+     * @param session (Optional) will be used to localize any text.
      */
     constructor(session?: Session);
     aspect(text: TextType, ...args: any[]): this;
@@ -2484,9 +2486,9 @@ export class VideoCard extends MediaCard implements IIsAttachment {
 /** Card builder class that simplifies building Animation cards. */
 export class AnimationCard extends MediaCard implements IIsAttachment {
 
-    /** 
-     * Creates a new AnimationCard. 
-     * @param session (Optional) will be used to localize any text. 
+    /**
+     * Creates a new AnimationCard.
+     * @param session (Optional) will be used to localize any text.
      */
     constructor(session?: Session);
 }
@@ -2494,43 +2496,43 @@ export class AnimationCard extends MediaCard implements IIsAttachment {
 /** Card builder class that simplifies building Media cards. */
 export class AudioCard extends MediaCard implements IIsAttachment{
 
-    /** 
-     * Creates a new Audio. 
-     * @param session (Optional) will be used to localize any text. 
+    /**
+     * Creates a new Audio.
+     * @param session (Optional) will be used to localize any text.
      */
-    constructor(session?: Session); 
+    constructor(session?: Session);
 }
 
 /** Card builder class that simplifies building Media cards. */
 export class MediaCard  implements IIsAttachment{
 
-    /** 
-     * Creates a new MediaCard. 
-     * @param session (Optional) will be used to localize any text. 
+    /**
+     * Creates a new MediaCard.
+     * @param session (Optional) will be used to localize any text.
      */
     constructor(session?: Session);
-    
+
     /** Title of the Card */
     title(text: TextType, ...args: any[]): this;
 
     /** Subtitle appears just below Title field, differs from Title in font styling only */
     subtitle(text: TextType, ...args: any[]): this;
-    
+
     /** Text field appears just below subtitle, differs from Subtitle in font styling only */
     text(text: TextType, ...args: any[]): this;
-    
+
     /** Messaging supports all media formats: audio, video, images and thumbnails as well to optimize content download.*/
     image(image: ICardImage|IIsCardImage): this;
 
     /** Media source for video, audio or animations */
     media(list: ICardMediaUrl[]): this;
-        
+
     /** Returns the JSON for the card*/
     toAttachment(): IAttachment;
 
     /** Should the media source reproduction run in a loop */
     autoloop(choice: boolean): this;
-    
+
     /** Should the media start automatically */
     autostart(choice: boolean): this;
 
@@ -2545,25 +2547,25 @@ export class MediaCard  implements IIsAttachment{
 export interface IIsCardMedia{
 
     /** Returns the url definition for a Media entity for a card */
-    toMedia(): ICardMediaUrl; 
+    toMedia(): ICardMediaUrl;
 }
 
 /** Definition of a media entity for a card */
 export class CardMedia implements IIsCardMedia{
-    
-    /** 
-     * Creates a new CardMedia, which defines a media entity for a card. 
-     * @param session (Optional) will be used to localize any text. 
+
+    /**
+     * Creates a new CardMedia, which defines a media entity for a card.
+     * @param session (Optional) will be used to localize any text.
      */
     constructor(session?: Session);
-    
+
     /** Url of the media */
     url(u: string): this;
-    
+
     /** Optional profile hint to the client to differentiate multiple MediaUrl objects from each other */
     profile(text: string): this;
-    
-    /** Returns the url definition for a Media entity for a card */    
+
+    /** Returns the url definition for a Media entity for a card */
     toMedia(): ICardMediaUrl;
 
     /** Factory method for creation of Card media entities */
@@ -2573,28 +2575,28 @@ export class CardMedia implements IIsCardMedia{
 /** Card builder class that simplifies building hero cards. Hero cards contain the same information as a thumbnail card, just with a larger more pronounced layout for the cards images. */
 export class HeroCard extends ThumbnailCard {
 
-    /** 
-     * Creates a new HeroCard. 
-     * @param session (Optional) will be used to localize any text. 
+    /**
+     * Creates a new HeroCard.
+     * @param session (Optional) will be used to localize any text.
      */
     constructor(session?: Session);
 }
 
 /** Card builder class that simplifies building signin cards. */
 export class SigninCard implements IIsAttachment {
-    
-    /** 
-     * Creates a new SigninCard. 
-     * @param session (Optional) will be used to localize any text. 
+
+    /**
+     * Creates a new SigninCard.
+     * @param session (Optional) will be used to localize any text.
      */
     constructor(session?: Session);
-    
+
     /** Title of the Card. */
     text(prompts: TextType, ...args: any[]): SigninCard;
-    
-    /** Signin button label and link. */  
+
+    /** Signin button label and link. */
     button(title: TextType, url: string): SigninCard;
-    
+
     /** Returns the JSON for the card, */
     toAttachment(): IAttachment;
 }
@@ -2602,34 +2604,34 @@ export class SigninCard implements IIsAttachment {
 /** Card builder class that simplifies building receipt cards. */
 export class ReceiptCard implements IIsAttachment {
 
-    /** 
-     * Creates a new ReceiptCard. 
-     * @param session (Optional) will be used to localize any text. 
+    /**
+     * Creates a new ReceiptCard.
+     * @param session (Optional) will be used to localize any text.
      */
     constructor(session?: Session);
-    
+
     /** Title of the Card. */
     title(text: TextType, ...args: any[]): ReceiptCard;
-    
-    /** Array of receipt items. */  
+
+    /** Array of receipt items. */
     items(list: IReceiptItem[]|IIsReceiptItem[]): ReceiptCard;
 
-    /** Array of additional facts to display to user (shipping charges and such.) Not all facts will be displayed on all channels. */ 
+    /** Array of additional facts to display to user (shipping charges and such.) Not all facts will be displayed on all channels. */
     facts(list: IFact[]|IIsFact[]): ReceiptCard;
 
-    /** This action will be activated when user taps on the card. Not all channels support tap actions. */  
+    /** This action will be activated when user taps on the card. Not all channels support tap actions. */
     tap(action: ICardAction|IIsCardAction): ReceiptCard;
-    
-    /** Total amount of money paid (or should be paid.) */  
+
+    /** Total amount of money paid (or should be paid.) */
     total(v: string): ReceiptCard;
 
     /** Total amount of TAX paid (or should be paid.) */
     tax(v: string): ReceiptCard;
 
-    /** Total amount of VAT paid (or should be paid.) */  
+    /** Total amount of VAT paid (or should be paid.) */
     vat(v: string): ReceiptCard;
 
-    /** Set of actions applicable to the current card. Not all channels support buttons and the number of allowed buttons varies by channel. */  
+    /** Set of actions applicable to the current card. Not all channels support buttons and the number of allowed buttons varies by channel. */
     buttons(list: ICardAction[]|IIsCardAction[]): ReceiptCard;
 
     /** Returns the JSON for the card. */
@@ -2639,33 +2641,33 @@ export class ReceiptCard implements IIsAttachment {
 /** Builder class to simplify adding items to a receipt card. */
 export class ReceiptItem implements IIsReceiptItem {
 
-    /** 
-     * Creates a new ReceiptItem. 
-     * @param session (Optional) will be used to localize any text. 
+    /**
+     * Creates a new ReceiptItem.
+     * @param session (Optional) will be used to localize any text.
      */
     constructor(session?: Session);
-    
+
     /** Title of the item. */
     title(text: TextType, ...args: any[]): ReceiptItem;
 
     /** Subtitle appears just below Title field, differs from Title in font styling only. On some channels may be combined with the [title](#title) or [text](#text). */
     subtitle(text: TextType, ...args: any[]): ReceiptItem;
-    
-    /** Text field appears just below subtitle, differs from Subtitle in font styling only. */  
+
+    /** Text field appears just below subtitle, differs from Subtitle in font styling only. */
     text(text: TextType, ...args: any[]): ReceiptItem;
-    
-    /** Image to display on the card. Some channels may either send the image as a seperate message or simply include a link to the image. */  
+
+    /** Image to display on the card. Some channels may either send the image as a seperate message or simply include a link to the image. */
     image(img: ICardImage|IIsCardImage): ReceiptItem;
 
     /** Amount with currency. */
     price(v: string): ReceiptItem;
-    
-    /** Number of items of given kind. */  
+
+    /** Number of items of given kind. */
     quantity(v: string): ReceiptItem;
-    
-    /** This action will be activated when user taps on the Item bubble. Not all channels support tap actions. */  
+
+    /** This action will be activated when user taps on the Item bubble. Not all channels support tap actions. */
     tap(action: ICardAction|IIsCardAction): ReceiptItem;
-    
+
     /** Returns the JSON for the item. */
     toItem(): IReceiptItem;
 
@@ -2675,20 +2677,20 @@ export class ReceiptItem implements IIsReceiptItem {
 
 /** Builder class to simplify creating a list of facts for a card like a receipt. */
 export class Fact implements IIsFact {
-    
-    /** 
-     * Creates a new Fact. 
-     * @param session (Optional) will be used to localize any text. 
+
+    /**
+     * Creates a new Fact.
+     * @param session (Optional) will be used to localize any text.
      */
     constructor(session?: Session);
-    
+
     /** Display name of the fact. */
     key(text: TextType, ...args: any[]): Fact;
-    
-    /** Display value of the fact. */  
+
+    /** Display value of the fact. */
     value(v: string): Fact;
 
-    /** Returns the JSON for the fact. */   
+    /** Returns the JSON for the fact. */
     toFact(): IFact;
 
     /** Creates a new Fact. */
@@ -2696,11 +2698,11 @@ export class Fact implements IIsFact {
 }
 
 
-/** 
- * Implement support for named actions which can be bound to a dialog to handle global utterances from the user like "help" or 
+/**
+ * Implement support for named actions which can be bound to a dialog to handle global utterances from the user like "help" or
  * "cancel". Actions get pushed onto and off of the dialog stack as part of dialogs so these listeners can
  * come into and out of scope as the conversation progresses. You can also bind named to actions to buttons
- * which let your bot respond to button clicks on cards that have maybe scrolled off the screen. 
+ * which let your bot respond to button clicks on cards that have maybe scrolled off the screen.
  */
 export class ActionSet {
     /**
@@ -2710,7 +2712,7 @@ export class ActionSet {
     clone(copyTo?: ActionSet): ActionSet;
 
     /**
-     * Called once for each dialog within a library to give the dialog a chance to add its 
+     * Called once for each dialog within a library to give the dialog a chance to add its
      * `triggerAction()` to the libraries global action set.  These triggers get mapped to
      * a `beginDialogAction()` that starts the dialog when the trigger condition is met.
      * @param actions Libraries global action set.
@@ -2719,9 +2721,9 @@ export class ActionSet {
     addDialogTrigger(actions: ActionSet, dialogId: string): void;
 
     /**
-     * Called during the [Library.findRoutes()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.library#findroutes) 
-     * call for each dialog on the stack to determine if any of the dialogs actions are triggered 
-     * by the users utterance. 
+     * Called during the [Library.findRoutes()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.library#findroutes)
+     * call for each dialog on the stack to determine if any of the dialogs actions are triggered
+     * by the users utterance.
      * @param context The context of the incoming message as well as the [dialogData](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session#dialogdata) for the evaluated dialog.
      * @param callback Function to invoke with the top candidate route(s).
      */
@@ -2736,9 +2738,9 @@ export class ActionSet {
 }
 
 /**
- * Base class for all dialogs. Dialogs are the core component of the BotBuilder 
+ * Base class for all dialogs. Dialogs are the core component of the BotBuilder
  * framework. Bots use Dialogs to manage arbitrarily complex conversations with
- * a user. 
+ * a user.
  */
 export abstract class Dialog extends ActionSet {
     /**
@@ -2767,7 +2769,7 @@ export abstract class Dialog extends ActionSet {
     /**
      * Called when a root dialog is being interrupted by another dialog. This gives the dialog
      * that's being interrupted a chance to run custom logic before it's removed from the stack.
-     * 
+     *
      * The dialog itself is responsible for clearing the dialog stack and starting the new dialog.
      * @param session Session object for the current conversation.
      * @param dialogId ID of the dialog that should be started.
@@ -2775,22 +2777,22 @@ export abstract class Dialog extends ActionSet {
      */
     dialogInterrupted(session: Session, dialogId: string, dialogArgs: any): void;
 
-    /** 
-     * Parses the users utterance and assigns a score from 0.0 - 1.0 indicating how confident the 
+    /**
+     * Parses the users utterance and assigns a score from 0.0 - 1.0 indicating how confident the
      * dialog is that it understood the users utterance.  This method is always called for the active
-     * dialog on the stack.  A score of 1.0 will indicate a perfect match and terminate any further 
-     * recognition.  
-     * 
-     * When the score is less than 1.0, every dialog on the stack will have its 
+     * dialog on the stack.  A score of 1.0 will indicate a perfect match and terminate any further
+     * recognition.
+     *
+     * When the score is less than 1.0, every dialog on the stack will have its
      * [recognizeAction()](#recognizeaction) method called as well to see if there are any named
-     * actions bound to the dialog that better matches the users utterance. Global actions registered 
+     * actions bound to the dialog that better matches the users utterance. Global actions registered
      * at the bot level will also be evaluated. If the dialog has a score higher then any bound actions,
-     * the dialogs [replyReceived()](#replyreceived) method will be called with the result object 
+     * the dialogs [replyReceived()](#replyreceived) method will be called with the result object
      * returned from the recognize() call.  This lets the dialog pass additional data collected during
      * the recognize phase to the replyReceived() method for handling.
-     * 
+     *
      * Should there be an action with a higher score then the dialog the action will be invoked instead
-     * of the dialogs replyReceived() method.  The dialog will stay on the stack and may be resumed 
+     * of the dialogs replyReceived() method.  The dialog will stay on the stack and may be resumed
      * at some point should the action invoke a new dialog so dialogs should prepare for unexpected calls
      * to [dialogResumed()](#dialogresumed).
      * @param context The context of the request.
@@ -2800,10 +2802,10 @@ export abstract class Dialog extends ActionSet {
 
     /**
      * Binds an action to the dialog that will make it the active dialog anytime it's triggered.
-     * The default behaviour is to interupt any existing dialog by clearing the stack and starting 
-     * the dialog at the root of the stack.  The dialog being interrupted can intercept this 
-     * interruption by adding a custom [onInterrupted](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.itriggeractionsoptions#oninterrupted) 
-     * handler to their trigger action options.  Additionally, you can customize the way the 
+     * The default behaviour is to interupt any existing dialog by clearing the stack and starting
+     * the dialog at the root of the stack.  The dialog being interrupted can intercept this
+     * interruption by adding a custom [onInterrupted](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.itriggeractionsoptions#oninterrupted)
+     * handler to their trigger action options.  Additionally, you can customize the way the
      * triggered dialog is started by providing a custom [onSelectAction](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.ibegindialogactionsoptions#onselectaction)
      * handler to your trigger action options.
      * @param options Options used to configure the action.
@@ -2811,12 +2813,12 @@ export abstract class Dialog extends ActionSet {
     triggerAction(options: ITriggerActionOptions): Dialog;
 
     /**
-     * Binds an action to the dialog that will cancel the dialog anytime it's triggered. When canceled, the 
+     * Binds an action to the dialog that will cancel the dialog anytime it's triggered. When canceled, the
      * dialogs parent will be resumed with a [resumed](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogresult#resumed) code indicating that it was [canceled](/en-us/node/builder/chat-reference/enums/_botbuilder_d_.resumereason#canceled).
      * @param name Unique name to assign the action.
      * @param msg (Optional) message to send the user prior to canceling the dialog.
-     * @param options (Optional) options used to configure the action. If [matches](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#matches) is specified the action will listen 
-     * for the user to say a word or phrase that triggers the action, otherwise the action needs to be bound to a button using [CardAction.dialogAction()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.cardaction#dialogaction) 
+     * @param options (Optional) options used to configure the action. If [matches](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#matches) is specified the action will listen
+     * for the user to say a word or phrase that triggers the action, otherwise the action needs to be bound to a button using [CardAction.dialogAction()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.cardaction#dialogaction)
      * to trigger the action.
      */
     cancelAction(name: string, msg?: TextOrMessageType, options?: ICancelActionOptions): Dialog;
@@ -2826,22 +2828,22 @@ export abstract class Dialog extends ActionSet {
      * useful to implement logic that handle user utterances like "start over".
      * @param name Unique name to assign the action.
      * @param msg (Optional) message to send the user prior to reloading the dialog.
-     * @param options (Optional) options used to configure the action. If [matches](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#matches) is specified the action will listen 
-     * for the user to say a word or phrase that triggers the action, otherwise the action needs to be bound to a button using [CardAction.dialogAction()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.cardaction#dialogaction) 
+     * @param options (Optional) options used to configure the action. If [matches](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#matches) is specified the action will listen
+     * for the user to say a word or phrase that triggers the action, otherwise the action needs to be bound to a button using [CardAction.dialogAction()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.cardaction#dialogaction)
      * to trigger the action. You can also use [dialogArgs](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#dialogargs) to pass additional params to the dialog when reloaded.
      */
     reloadAction(name: string, msg?: TextOrMessageType, options?: IBeginDialogActionOptions): Dialog;
 
     /**
-     * Binds an action to the dialog that will start another dialog anytime it's triggered. The new 
-     * dialog will be pushed onto the stack so it does not automatically end the current task. The 
+     * Binds an action to the dialog that will start another dialog anytime it's triggered. The new
+     * dialog will be pushed onto the stack so it does not automatically end the current task. The
      * current task will be continued once the new dialog ends. The built-in prompts will automatically
-     * re-prompt the user once this happens but that behaviour can be disabled by setting the [promptAfterAction](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.ipromptoptions#promptafteraction) 
+     * re-prompt the user once this happens but that behaviour can be disabled by setting the [promptAfterAction](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.ipromptoptions#promptafteraction)
      * flag when calling a built-in prompt.
      * @param name Unique name to assign the action.
      * @param id ID of the dialog to start.
-     * @param options (Optional) options used to configure the action. If [matches](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#matches) is specified the action will listen 
-     * for the user to say a word or phrase that triggers the action, otherwise the action needs to be bound to a button using [CardAction.dialogAction()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.cardaction#dialogaction) 
+     * @param options (Optional) options used to configure the action. If [matches](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#matches) is specified the action will listen
+     * for the user to say a word or phrase that triggers the action, otherwise the action needs to be bound to a button using [CardAction.dialogAction()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.cardaction#dialogaction)
      * to trigger the action. You can also use [dialogArgs](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#dialogargs) to pass additional params to the dialog being started.
      */
     beginDialogAction(name: string, id: string, options?: IBeginDialogActionOptions): Dialog;
@@ -2850,42 +2852,42 @@ export abstract class Dialog extends ActionSet {
      * Binds an action that will end the conversation with the user when triggered.
      * @param name Unique name to assign the action.
      * @param msg (Optional) message to send the user prior to ending the conversation.
-     * @param options (Optional) options used to configure the action. If [matches](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#matches) is specified the action will listen 
-     * for the user to say a word or phrase that triggers the action, otherwise the action needs to be bound to a button using [CardAction.dialogAction()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.cardaction#dialogaction) 
+     * @param options (Optional) options used to configure the action. If [matches](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#matches) is specified the action will listen
+     * for the user to say a word or phrase that triggers the action, otherwise the action needs to be bound to a button using [CardAction.dialogAction()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.cardaction#dialogaction)
      * to trigger the action.
      */
     endConversationAction(name: string, msg?: TextOrMessageType, options?: ICancelActionOptions): Dialog;
 
     /**
-     * Binds a custom action to the dialog that will call the passed in [onSelectAction](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#onselectaction) 
+     * Binds a custom action to the dialog that will call the passed in [onSelectAction](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#onselectaction)
      * handler when triggered.
-     * @param options The options used to configure the action. If [matches](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#matches) is specified the action will listen 
+     * @param options The options used to configure the action. If [matches](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#matches) is specified the action will listen
      * for the user to say a word or phrase that triggers the action. Custom matching logic can be provided using [onFindAction](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#onfindaction).
      */
     customAction(options: IDialogActionOptions): Library;
 }
 
-/** 
- * Dialog actions offer static shortcuts to implementing common actions. They also implement support for 
- * named actions which can be bound to a dialog to handle global utterances from the user like "help" or 
+/**
+ * Dialog actions offer static shortcuts to implementing common actions. They also implement support for
+ * named actions which can be bound to a dialog to handle global utterances from the user like "help" or
  * "cancel". Actions get pushed onto and off of the dialog stack as part of dialogs so these listeners can
  * come into and out of scope as the conversation progresses. You can also bind named to actions to buttons
- * which let your bot respond to button clicks on cards that have maybe scrolled off the screen. 
+ * which let your bot respond to button clicks on cards that have maybe scrolled off the screen.
  */
 export class DialogAction {
     /**
-     * Returns a closure that will send a simple text message to the user. 
+     * Returns a closure that will send a simple text message to the user.
      * @param msg Text of the message to send. The message will be localized using the sessions configured [localizer](#localizer). If arguments are passed in the message will be formatted using [sprintf-js](https://github.com/alexei/sprintf.js) (see the docs for details.)
-     * @param args (Optional) arguments used to format the final output string. 
+     * @param args (Optional) arguments used to format the final output string.
      */
     static send(msg: string, ...args: any[]): IDialogWaterfallStep;
 
     /**
-     * Returns a closure that will passes control of the conversation to a new dialog.  
+     * Returns a closure that will passes control of the conversation to a new dialog.
      * @param id Unique ID of the dialog to start.
      * @param args (Optional) arguments to pass to the dialogs begin() method.
      */
-    static beginDialog<T>(id: string, args?: T): IDialogWaterfallStep; 
+    static beginDialog<T>(id: string, args?: T): IDialogWaterfallStep;
 
     /**
      * Returns a closure that will end the current dialog.
@@ -2898,7 +2900,7 @@ export class DialogAction {
      * to define a new dialog for the prompt using bot.add('/myPrompt', builder.DialogAction.)
      * @param promptType Type of built-in prompt to validate.
      * @param validator Function used to validate the response. Should return true if the response is valid.
-     * @param validator.response The users [IDialogResult.response](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogresult.html#response) returned by the built-in prompt. 
+     * @param validator.response The users [IDialogResult.response](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogresult.html#response) returned by the built-in prompt.
      * @example
      * <pre><code>
      * var bot = new builder.BotConnectorBot();
@@ -2918,7 +2920,7 @@ export class DialogAction {
      *     return response === '42';
      * }));
      * </code></pre>
-     */    
+     */
     static validatedPrompt(promptType: PromptType, validator: (response: any) => boolean): Dialog;
 }
 
@@ -2926,26 +2928,26 @@ export class DialogAction {
 /**
  * A library of related dialogs used for routing purposes. Libraries can be chained together to enable
  * the development of complex bots. The [UniversalBot](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.universalbot.html)
- * class is itself a Library that forms the root of this chain. 
- * 
- * Libraries of reusable parts can be developed by creating a new Library instance and adding dialogs 
- * just as you would to a bot. Your library should have a unique name that corresponds to either your 
+ * class is itself a Library that forms the root of this chain.
+ *
+ * Libraries of reusable parts can be developed by creating a new Library instance and adding dialogs
+ * just as you would to a bot. Your library should have a unique name that corresponds to either your
  * libraries website or NPM module name.  Bots can then reuse your library by simply adding your parts
  * Library instance to their bot using [UniversalBot.library()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.universalbot.html#library).
- * If your library itself depends on other libraries you should add them to your library as a dependency 
- * using [Library.library()](#library). You can easily manage multiple versions of your library by 
+ * If your library itself depends on other libraries you should add them to your library as a dependency
+ * using [Library.library()](#library). You can easily manage multiple versions of your library by
  * adding a version number to your library name.
- * 
+ *
  * To invoke dialogs within your library bots will need to call [session.beginDialog()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session.html#begindialog)
- * with a fully qualified dialog id in the form of '<libName>:<dialogId>'. You'll typically hide 
+ * with a fully qualified dialog id in the form of '<libName>:<dialogId>'. You'll typically hide
  * this from the developer by exposing a function from their module that starts the dialog for them.
  * So calling something like `myLib.someDialog(session, { arg: '' });` would end up calling
  * `session.beginDialog('myLib:someDialog', args);` under the covers.
- * 
+ *
  * It's worth noting that dialogs are always invoked within the current dialog so once your within
- * a dialog from your library you don't need to prefix every beginDialog() call your with your 
- * libraries name. It's only when crossing from one library context to another that you need to 
- * include the library name prefix.  
+ * a dialog from your library you don't need to prefix every beginDialog() call your with your
+ * libraries name. It's only when crossing from one library context to another that you need to
+ * include the library name prefix.
  */
 export class Library {
     /** Supported [routeType](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.irouteresult#routetype) values returned by default from [findRoutes()](#findroutes). */
@@ -2960,15 +2962,15 @@ export class Library {
         ActiveDialog: string;
     };
 
-    /** 
+    /**
      * The libraries unique namespace. This is used to issolate the libraries dialogs and localized
-     * prompts. 
+     * prompts.
      */
     readonly name: string;
 
-    /** 
+    /**
      * Creates a new instance of the library.
-     * @param name Unique namespace for the library. 
+     * @param name Unique namespace for the library.
      */
     constructor(name: string);
 
@@ -2979,51 +2981,51 @@ export class Library {
      */
     clone(copyTo?: Library, newName?: string): Library;
 
-    /** 
-     * Gets or sets the path to the libraries "/locale/" folder containing its localized prompts. 
+    /**
+     * Gets or sets the path to the libraries "/locale/" folder containing its localized prompts.
      * The prompts for the library should be stored in a "/locale/<IETF_TAG>/<NAMESPACE>.json" file
      * under this path where "<IETF_TAG>" representes the 2-3 digit language tage for the locale and
-     * "<NAMESPACE>" is a filename matching the libraries namespace. 
-     * @param path (Optional) path to the libraries "/locale/" folder. If specified this will update the libraries path. 
+     * "<NAMESPACE>" is a filename matching the libraries namespace.
+     * @param path (Optional) path to the libraries "/locale/" folder. If specified this will update the libraries path.
      */
     localePath(path?: string): string;
 
-    /** 
-     * Attempts to match a users text utterance to an intent using the libraries recognizers. See 
-     * [IIntentRecognizer.recognize()](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iintentrecognizer#recognize) 
+    /**
+     * Attempts to match a users text utterance to an intent using the libraries recognizers. See
+     * [IIntentRecognizer.recognize()](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iintentrecognizer#recognize)
      * for details.
      * @param context Read-only recognizer context for the current conversation.
      * @param callback Function that should be invoked upon completion of the recognition.
      * @param callback.err Any error that occured during the operation.
-     * @param callback.result The result of the recognition operation. 
+     * @param callback.result The result of the recognition operation.
      */
     recognize(context: IRecognizeContext, callback: (err: Error, result: IIntentRecognizerResult) => void): void;
 
     /**
      * Adds a new recognizer plugin to the library.
-     * @param plugin The recognizer to add. 
+     * @param plugin The recognizer to add.
      */
     recognizer(plugin: IIntentRecognizer): IntentDialog;
 
     /**
-     * Searches for candidate routes to handle the current message. To actually initiate the 
-     * handling of the message you should call [selectRoute()](#selectroute) with one of the 
-     * returned results. 
-     * 
+     * Searches for candidate routes to handle the current message. To actually initiate the
+     * handling of the message you should call [selectRoute()](#selectroute) with one of the
+     * returned results.
+     *
      * The default search logic can be overriden using [onFindRoute()](#onfindroute) and only the
-     * current library is searched so you should call `findRoutes()` seperately for each library 
+     * current library is searched so you should call `findRoutes()` seperately for each library
      * within the hierarchy.
      * @param context Read-only recognizer context for the current conversation.
      * @param callback Function that should be invoked with the found routes.
      * @param callback.err Any error that occured during the operation.
-     * @param callback.routes List of routes best suited to handle the current message. 
+     * @param callback.routes List of routes best suited to handle the current message.
      */
     findRoutes(context: IRecognizeContext, callback: (err: Error, routes: IRouteResult[]) => void): void
 
     /**
-     * Replaces [findRoutes()](#findroutes) default route searching logic with a custom 
+     * Replaces [findRoutes()](#findroutes) default route searching logic with a custom
      * implementation.
-     * @param handler Function that will be invoked anytime `findRoutes()` is called for the library. 
+     * @param handler Function that will be invoked anytime `findRoutes()` is called for the library.
      */
     onFindRoutes(handler: IFindRoutesHandler): void;
 
@@ -3037,18 +3039,18 @@ export class Library {
 
     /**
      * Replaces the default logic for [selectRoute()](#selectroute) with a custom implementation.
-     * @param handler Function that will be invoked anytime `selectRoute()` is called. 
+     * @param handler Function that will be invoked anytime `selectRoute()` is called.
      */
     onSelectRoute(handler: ISelectRouteHandler): void;
 
     /**
-     * Gets the active dialogs confidence that it understands the current message. The dialog 
+     * Gets the active dialogs confidence that it understands the current message. The dialog
      * must be a member of the current library, otherwise a score of 0.0 will be returned.
      * @param context Read-only recognizer context for the current conversation.
      * @param callback Function that should be invoked with the found routes.
      * @param callback.err Any error that occured during the operation.
      * @param callback.routes List of routes best suited to handle the current message.
-     * @param dialogStack (Optional) dialog stack to search over. The default behaviour is to search over the sessions current dialog stack. 
+     * @param dialogStack (Optional) dialog stack to search over. The default behaviour is to search over the sessions current dialog stack.
      */
     findActiveDialogRoutes(context: IRecognizeContext, callback: (err: Error, routes: IRouteResult[]) => void, dialogStack?: IDialogState[]): void;
 
@@ -3065,7 +3067,7 @@ export class Library {
      * @param callback Function that should be invoked with the found routes.
      * @param callback.err Any error that occured during the operation.
      * @param callback.routes List of routes best suited to handle the current message.
-     * @param dialogStack (Optional) dialog stack to search over. The default behaviour is to search over the sessions current dialog stack. 
+     * @param dialogStack (Optional) dialog stack to search over. The default behaviour is to search over the sessions current dialog stack.
      */
     findStackActionRoutes(context: IRecognizeContext, callback: (err: Error, routes: IRouteResult[]) => void, dialogStack?: IDialogState[]): void;
 
@@ -3098,13 +3100,13 @@ export class Library {
      * @param dialog (Optional) dialog or waterfall to register.
      * * __dialog:__ _{Dialog}_ - Dialog to add.
      * * __dialog:__ _{IDialogWaterfallStep[]}_ - Waterfall of steps to execute. See [IDialogWaterfallStep](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogwaterfallstep.html) for details.
-     * * __dialog:__ _{IDialogWaterfallStep}_ - Single step waterfall. Calling a built-in prompt or starting a new dialog will result in the current dialog ending upon completion of the child prompt/dialog. 
+     * * __dialog:__ _{IDialogWaterfallStep}_ - Single step waterfall. Calling a built-in prompt or starting a new dialog will result in the current dialog ending upon completion of the child prompt/dialog.
      * @param replace (Optional) if true, the dialog should replace the existing dialog if already registered.
      */
     dialog(id: string, dialog?: Dialog|IDialogWaterfallStep[]|IDialogWaterfallStep, replace?:boolean): Dialog;
 
     /**
-     * Searches the library and all of its dependencies for a specific dialog. Returns the dialog 
+     * Searches the library and all of its dependencies for a specific dialog. Returns the dialog
      * if found, otherwise null.
      * @param libName Name of the library containing the dialog.
      * @param dialogId Unique ID of the dialog within the library.
@@ -3112,16 +3114,16 @@ export class Library {
     findDialog(libName: string, dialogId: string): Dialog;
 
     /**
-     * Enumerates all of the libraries dialogs. 
+     * Enumerates all of the libraries dialogs.
      * @param callback Iterator function to call with each dialog.
      * @param callback.dialog The current dialog.
      * @param id Unique ID of the dialog.
      */
     forEachDialog(callback: (dialog: Dialog, id: string) => void): void;
 
-    /**  
+    /**
      * Registers or returns a library dependency.
-     * @param lib 
+     * @param lib
      * * __lib:__ _{Library}_ - Library to register as a dependency.
      * * __lib:__ _{string}_ - Unique name of the library to lookup. All dependencies will be searched as well.
      */
@@ -3129,7 +3131,7 @@ export class Library {
 
     /**
      * Enumerates all of the libraries child libraries. The caller should take appropriate steps to
-     * avoid circular references when enumerating the hierarchy. In most cases calling 
+     * avoid circular references when enumerating the hierarchy. In most cases calling
      * [libraryList()](#librarylist) is a better choice as it already contains logic to avoid cycles.
      * @param callback Iterator function to call with each child libray.
      * @param callback.library The current child.
@@ -3145,15 +3147,15 @@ export class Library {
     libraryList(reverse?: boolean): Library[];
 
     /**
-     * Registers a global action that will start another dialog anytime it's triggered. The new 
-     * dialog will be pushed onto the stack so it does not automatically end any current task. The 
+     * Registers a global action that will start another dialog anytime it's triggered. The new
+     * dialog will be pushed onto the stack so it does not automatically end any current task. The
      * current task will be continued once the new dialog ends. The built-in prompts will automatically
-     * re-prompt the user once this happens but that behaviour can be disabled by setting the [promptAfterAction](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.ipromptoptions#promptafteraction) 
+     * re-prompt the user once this happens but that behaviour can be disabled by setting the [promptAfterAction](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.ipromptoptions#promptafteraction)
      * flag when calling a built-in prompt.
      * @param name Unique name to assign the action.
      * @param id ID of the dialog to start.
-     * @param options (Optional) options used to configure the action. If [matches](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#matches) is specified the action will listen 
-     * for the user to say a word or phrase that triggers the action, otherwise the action needs to be bound to a button using [CardAction.dialogAction()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.cardaction#dialogaction) 
+     * @param options (Optional) options used to configure the action. If [matches](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#matches) is specified the action will listen
+     * for the user to say a word or phrase that triggers the action, otherwise the action needs to be bound to a button using [CardAction.dialogAction()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.cardaction#dialogaction)
      * to trigger the action. You can also use [dialogArgs](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#dialogargs) to pass additional params to the dialog being started.
      */
     beginDialogAction(name: string, id: string, options?: IDialogActionOptions): Dialog;
@@ -3162,26 +3164,26 @@ export class Library {
      * Registers a global action that will end the conversation with the user when triggered.
      * @param name Unique name to assign the action.
      * @param msg (Optional) message to send the user prior to ending the conversation.
-     * @param options (Optional) options used to configure the action. If [matches](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#matches) is specified the action will listen 
-     * for the user to say a word or phrase that triggers the action, otherwise the action needs to be bound to a button using [CardAction.dialogAction()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.cardaction#dialogaction) 
+     * @param options (Optional) options used to configure the action. If [matches](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#matches) is specified the action will listen
+     * for the user to say a word or phrase that triggers the action, otherwise the action needs to be bound to a button using [CardAction.dialogAction()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.cardaction#dialogaction)
      * to trigger the action.
      */
     endConversationAction(name: string, msg?: TextOrMessageType, options?: ICancelActionOptions): Dialog;
 
     /**
-     * Registers a custom global action that will call the passed in [onSelectAction](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#onselectaction) 
+     * Registers a custom global action that will call the passed in [onSelectAction](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#onselectaction)
      * handler when triggered.
-     * @param options The options used to configure the action. If [matches](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#matches) is specified the action will listen 
+     * @param options The options used to configure the action. If [matches](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#matches) is specified the action will listen
      * for the user to say a word or phrase that triggers the action. Custom matching logic can be provided using [onFindAction](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.idialogactionoptions#onfindaction).
      */
     customAction(options: IDialogActionOptions): Library;
 
     /**
      * Helper method called from the various route finding methods to manage adding a candidate
-     * route to the result set. 
-     * 
-     * * If the score is greater then the current best match in the set a new result set will be returned containing just the new match. 
-     * * If the score is equal to the current best match it will be added to the existing set. 
+     * route to the result set.
+     *
+     * * If the score is greater then the current best match in the set a new result set will be returned containing just the new match.
+     * * If the score is equal to the current best match it will be added to the existing set.
      * * If the score is less than the current best match it will be ignored.
      * @param route The candidate route to add to the set.
      * @param current (Optional) result set to add the route too. If missing then a new set with just the route will be returned.
@@ -3191,27 +3193,27 @@ export class Library {
     /**
      * Finds the best route to use within a result set containing multiple ambiguous routes. The
      * following disambigution strategy will be used:
-     * 
-     * 1. __<custom>__: Custom route types are the highest priority and will alwsays be preferred. This lets the developer override routing within a bot in very powerful way.  
+     *
+     * 1. __<custom>__: Custom route types are the highest priority and will alwsays be preferred. This lets the developer override routing within a bot in very powerful way.
      * 2. __ActiveDialog__: The active dialog is the next highest priority.
      * 3. __StackAction__: Stack actions are the next highest priority and the action with the deepest stack position will be returned.
      * 4. __GlobalAction__: Global actions are the lowest priority. If a `dialogStack` is past in the actions from the library deepest on the stack will be favored. Otherwise the first one will be returned.
      * @param routes Array of candidate routes to filter.
-     * @param dialogStack (Optional) dialog stack used to determine which libraries global actions to favor. 
+     * @param dialogStack (Optional) dialog stack used to determine which libraries global actions to favor.
      * @param rootLibraryName (Optional) library namespace to prefer when disambiguating global actions and there's no dialogs on the stack.
      */
     static bestRouteResult(routes: IRouteResult[], dialogStack?: IDialogState[], rootLibraryName?: string): IRouteResult;
 }
 
 /**
- * Base class for built-in prompts and can be used to build new custom prompts. The Prompt class 
+ * Base class for built-in prompts and can be used to build new custom prompts. The Prompt class
  * provides the basic logic to prompt/re-prompt a user and provides a set of extensible hooks to
  * customize the prompts recognition of the users reply as well as the output sent to the user.
- * 
- * Prompts should always have at least one [onRecognize()](#onrecognize) handler registered and 
+ *
+ * Prompts should always have at least one [onRecognize()](#onrecognize) handler registered and
  * they support adding any number of [matches()](#matches) or [matchesAny()](#matchesany) handlers
  * which can be used to add special user initiated commands to the prompt.  For instance, the
- * built-in prompts add a `matches('BotBuilder.RepeatIntent')` to listen for a user to ask to 
+ * built-in prompts add a `matches('BotBuilder.RepeatIntent')` to listen for a user to ask to
  * have a prompt repeated, causing the prompt to send its initial prompt again.
  */
 export class Prompt<T extends IPromptFeatures> extends Dialog {
@@ -3223,14 +3225,14 @@ export class Prompt<T extends IPromptFeatures> extends Dialog {
     constructor(features?: IPromptFeatures);
 
     /**
-     * Processes messages received from the user. Called by the dialog system. 
+     * Processes messages received from the user. Called by the dialog system.
      * @param session Session object for the current conversation.
      * @param (Optional) recognition results returned from a prior call to the dialogs [recognize()](#recognize) method.
      */
     replyReceived(session: Session, recognizeResult?: IRecognizeResult): void;
 
     /**
-     * Sends a prompt to the user for the current turn. This can be called from a [matches()][#matches] 
+     * Sends a prompt to the user for the current turn. This can be called from a [matches()][#matches]
      * handler to manually send a prompt/reprompt to the user. To force sending of the initial prompt
      * you would need to set `session.dialogData.turns = 0;` before calling `sendPrompt()`.
      * @param session Session object for the current conversation.
@@ -3240,7 +3242,7 @@ export class Prompt<T extends IPromptFeatures> extends Dialog {
     /**
      * Creates the message to send for the prompt. This is called automatically by [sendPrompt()](#sendprompt)
      * so in most cases you'll want to register a [onFormatMessage()](#onformatmessage) handler to
-     * customize the message sent for a prompt. You should only need to call this method if you're 
+     * customize the message sent for a prompt. You should only need to call this method if you're
      * implementing your own `sendPrompt()` logic.
      * @param session Session object for the current conversation.
      * @param text Current prompt/retryPrompt text.
@@ -3250,9 +3252,9 @@ export class Prompt<T extends IPromptFeatures> extends Dialog {
     formatMessage(session: Session, text: TextType, speak: TextType, callback: (err: Error, msg: IMessage) => void): void;
 
     /**
-     * Registers a handler that will be called every time the prompt is about to send a message to 
+     * Registers a handler that will be called every time the prompt is about to send a message to
      * the user. You can use this hook to implement your own custom prompt sending logic.
-     * 
+     *
      * Multiple handlers can be registered and calling `next()` will invoke the next handler in
      * the chain. The final handler performs the prompts default logic which is to create a new
      * message using [formatMessage()](#formatmessage) and then send it.
@@ -3262,10 +3264,10 @@ export class Prompt<T extends IPromptFeatures> extends Dialog {
 
     /**
      * Registers a handler that will be called to create the outgoing [IMessage](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.imessage)
-     * that will be sent for the prompt.  This handler is only called when the current 
+     * that will be sent for the prompt.  This handler is only called when the current
      * prompt/retryPrompt is of type `string|string[]`. Anytime the prompt/retryPrompt is an
      * `IMessage|IIsMessage` the configured message is used so your handler will not be called.
-     * 
+     *
      * Multiple handlers can be registered and the first handler to call `callback()` with a message
      * will be used. Calling `callback(null, null)` will cause processing to move to the next handler
      * in the chain.
@@ -3275,20 +3277,20 @@ export class Prompt<T extends IPromptFeatures> extends Dialog {
 
     /**
      * Registers a handler that will be called everytime the prompt receives a reply from the user.
-     * The handlers `callback()` can be used to return a confidence score that it understood the 
-     * users input as well as the value that should be returned to the caller of the prompt. 
-     * 
+     * The handlers `callback()` can be used to return a confidence score that it understood the
+     * users input as well as the value that should be returned to the caller of the prompt.
+     *
      * Calling `callback(null, 1.0, true);` would indicate a high confidence that the user answered
-     * the prompt and would return a `boolean` true as the response from the prompt. Any response 
-     * type is possible, including objects. Calling `callback(null, 0.0);` indicates that the users 
+     * the prompt and would return a `boolean` true as the response from the prompt. Any response
+     * type is possible, including objects. Calling `callback(null, 0.0);` indicates that the users
      * input was not understood at all and that they should be re-prompted.
-     * 
+     *
      * Multiple handlers can be registered and unlike the other handler types, all of the registered
      * will be called and handler providing the highest confidence score will be chosen as the winner.
      * When customizing one of the built-in prompt types you'll often want to disable the prompts
      * default recognizer logic. This can be achieved by setting the [features](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.ipromptfeatures)
      * of the prompt when you create it. Just keep in mind that if you completely disable the prompts
-     * default recognizer logic, you'll need to do all of the recognition yourself. 
+     * default recognizer logic, you'll need to do all of the recognition yourself.
      * @param handler Function that will be called to recognize the users reply to a prompt.
      */
     onRecognize(handler: (context: IRecognizeDialogContext, callback: (err: Error, score: number, response?: any) => void) => void): Prompt<any>;
@@ -3305,7 +3307,7 @@ export class Prompt<T extends IPromptFeatures> extends Dialog {
      * @param dialogId
      * * __dialogId:__ _{string} - The ID of a dialog to begin when the intent is matched.
      * * __dialogId:__ _{IDialogWaterfallStep[]}_ - Waterfall of steps to execute when the intent is matched.
-     * * __dialogId:__ _{IDialogWaterfallStep}_ - Single step waterfall to execute when the intent is matched. Calling a built-in prompt or starting a new dialog will result in the current dialog ending upon completion of the child prompt/dialog. 
+     * * __dialogId:__ _{IDialogWaterfallStep}_ - Single step waterfall to execute when the intent is matched. Calling a built-in prompt or starting a new dialog will result in the current dialog ending upon completion of the child prompt/dialog.
      * @param dialogArgs (Optional) arguments to pass the dialog that started when `dialogId` is a _{string}_.
      */
     matches(intent: RegExp|string, dialogId: string|IDialogWaterfallStep[]|IDialogWaterfallStep, dialogArgs?: any): IntentDialog;
@@ -3322,7 +3324,7 @@ export class Prompt<T extends IPromptFeatures> extends Dialog {
      * @param dialogId
      * * __dialogId:__ _{string} - The ID of a dialog to begin when the intent is matched.
      * * __dialogId:__ _{IDialogWaterfallStep[]}_ - Waterfall of steps to execute when the intent is matched.
-     * * __dialogId:__ _{IDialogWaterfallStep}_ - Single step waterfall to execute when the intent is matched. Calling a built-in prompt or starting a new dialog will result in the current dialog ending upon completion of the child prompt/dialog. 
+     * * __dialogId:__ _{IDialogWaterfallStep}_ - Single step waterfall to execute when the intent is matched. Calling a built-in prompt or starting a new dialog will result in the current dialog ending upon completion of the child prompt/dialog.
      * @param dialogArgs (Optional) arguments to pass the dialog that started when `dialogId` is a _{string}_.
      */
     matchesAny(intent: RegExp[]|string[], dialogId: string|IDialogWaterfallStep[]|IDialogWaterfallStep, dialogArgs?: any): IntentDialog;
@@ -3330,7 +3332,7 @@ export class Prompt<T extends IPromptFeatures> extends Dialog {
     /**
      * Adds a new recognizer plugin to the Prompt which will be run everytime the user replies
      * to the prompt.
-     * @param plugin The recognizer to add. 
+     * @param plugin The recognizer to add.
      */
     recognizer(plugin: IIntentRecognizer): IntentDialog;
 
@@ -3339,7 +3341,7 @@ export class Prompt<T extends IPromptFeatures> extends Dialog {
 
     /**
      * Applies a new set of features for the prompt. Normally called from a derived classes constructor
-     * to apply feature options passed in to the derived class.  
+     * to apply feature options passed in to the derived class.
      * @param features New features to apply.
      */
     protected updateFeatures(features: T): Prompt<any>;
@@ -3376,8 +3378,8 @@ export class PromptChoice extends Prompt<IPromptChoiceFeatures> {
      * Returns the list of dynamic or static choices for the prompt. This method is typically called
      * twice, once to get the list of choices to display and a second time to get the list of choices
      * to recognize over.
-     * @param context Read-only recognizer context for the current conversation. 
-     * @param recognizePhase If true, the list of choices will be used to recognize the users utterance. Otherwise they will be used to render a list of available choices to the user. 
+     * @param context Read-only recognizer context for the current conversation.
+     * @param recognizePhase If true, the list of choices will be used to recognize the users utterance. Otherwise they will be used to render a list of available choices to the user.
      * @param callback Function that will be called with the prompts list of choices.
      */
     findChoices(context: IRecognizeContext, recognizePhase: boolean, callback: (err: Error, choices: IChoice[]) => void): void;
@@ -3388,10 +3390,10 @@ export class PromptChoice extends Prompt<IPromptChoiceFeatures> {
      * user and a second time to retrieve the list of choices to compare against the users utterance.
      * No caching of the returned choices is done and the handler will be called for every turn of ability
      * conversation so you shoudl implement your own caching as appropriate.
-     * 
-     * Multiple handlers can be registered and the first handler to return a valid (not `null`) list 
+     *
+     * Multiple handlers can be registered and the first handler to return a valid (not `null`) list
      * of choices will be used.
-     * @param handler Function to call when a list of choices is need. The `recognizePhase` parameter will be "true" if the choices will be used to recognize the users response. 
+     * @param handler Function to call when a list of choices is need. The `recognizePhase` parameter will be "true" if the choices will be used to recognize the users response.
      */
     onChoices(handler: (context: IRecognizeContext, callback: (err: Error, choices?: IChoice[]) => void, recognizePhase?: boolean) => void): PromptChoice;
 
@@ -3453,12 +3455,12 @@ declare global {
      */
     export interface IPrompts {
         /**
-         * Captures from the user a raw string of text. 
+         * Captures from the user a raw string of text.
          * @param session Session object for the current conversation.
-         * @param prompt 
+         * @param prompt
          * * __prompt:__ _{string}_ - Initial message to send the user.
-         * * __prompt:__ _{string[]}_ - Array of possible messages to send user. One will be chosen at random. 
-         * * __prompt:__ _{IMessage|IIsMessage}_ - Initial message to send the user. Message can contain attachments. 
+         * * __prompt:__ _{string[]}_ - Array of possible messages to send user. One will be chosen at random.
+         * * __prompt:__ _{IMessage|IIsMessage}_ - Initial message to send the user. Message can contain attachments.
          * @param options (Optional) parameters to control the behaviour of the prompt.
          */
         text(session: Session, prompt: TextOrMessageType, options?: IPromptTextOptions): void;
@@ -3466,10 +3468,10 @@ declare global {
         /**
          * Prompts the user to enter a number.
          * @param session Session object for the current conversation.
-         * @param prompt 
+         * @param prompt
          * * __prompt:__ _{string}_ - Initial message to send the user.
-         * * __prompt:__ _{string[]}_ - Array of possible messages to send user. One will be chosen at random. 
-         * * __prompt:__ _{IMessage|IIsMessage}_ - Initial message to send the user. Message can contain attachments. 
+         * * __prompt:__ _{string[]}_ - Array of possible messages to send user. One will be chosen at random.
+         * * __prompt:__ _{IMessage|IIsMessage}_ - Initial message to send the user. Message can contain attachments.
          * @param options (Optional) parameters to control the behaviour of the prompt.
          */
         number(session: Session, prompt: TextOrMessageType, options?: IPromptNumberOptions): void;
@@ -3477,10 +3479,10 @@ declare global {
         /**
          * Prompts the user to confirm an action with a yes/no response.
          * @param session Session object for the current conversation.
-         * @param prompt 
+         * @param prompt
          * * __prompt:__ _{string}_ - Initial message to send the user.
-         * * __prompt:__ _{string[]}_ - Array of possible messages to send user. One will be chosen at random. 
-         * * __prompt:__ _{IMessage|IIsMessage}_ - Initial message to send the user. Message can contain attachments. 
+         * * __prompt:__ _{string[]}_ - Array of possible messages to send user. One will be chosen at random.
+         * * __prompt:__ _{IMessage|IIsMessage}_ - Initial message to send the user. Message can contain attachments.
          * @param options (Optional) parameters to control the behaviour of the prompt.
          */
         confirm(session: Session, prompt: TextOrMessageType, options?: IPromptOptions): void;
@@ -3488,15 +3490,15 @@ declare global {
         /**
          * Prompts the user to choose from a list of options.
          * @param session Session object for the current conversation.
-         * @param prompt 
+         * @param prompt
          * * __prompt:__ _{string}_ - Initial message to send the user.
-         * * __prompt:__ _{string[]}_ - Array of possible messages to send user. One will be chosen at random. 
+         * * __prompt:__ _{string[]}_ - Array of possible messages to send user. One will be chosen at random.
          * * __prompt:__ _{IMessage|IIsMessage}_ - Initial message to send the user. Message can contain attachments. Any [listStyle](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.ipromptoptions.html#liststyle) options will be ignored.
-         * @param choices 
+         * @param choices
          * * __choices:__ _{string}_ - List of choices as a pipe ('|') delimted string.
          * * __choices:__ _{Object}_ - List of choices expressed as an Object map. The objects field names will be used to build the list of values.
-         * * __choices:__ _{string[]}_ - List of choices as an array of strings. 
-         * * __choices:__ _{IChoice[]}_ - List of choices as an array of IChoice objects. 
+         * * __choices:__ _{string[]}_ - List of choices as an array of strings.
+         * * __choices:__ _{IChoice[]}_ - List of choices as an array of IChoice objects.
          * @param options (Optional) parameters to control the behaviour of the prompt.
          */
         choice(session: Session, prompt: TextOrMessageType, choices: string|Object|string[]|IChoice[], options?: IPromptChoiceOptions): void;
@@ -3504,10 +3506,10 @@ declare global {
         /**
          * Prompts the user to enter a time.
          * @param session Session object for the current conversation.
-         * @param prompt 
+         * @param prompt
          * * __prompt:__ _{string}_ - Initial message to send the user.
-         * * __prompt:__ _{string[]}_ - Array of possible messages to send user. One will be chosen at random. 
-         * * __prompt:__ _{IMessage|IIsMessage}_ - Initial message to send the user. Message can contain attachments. 
+         * * __prompt:__ _{string[]}_ - Array of possible messages to send user. One will be chosen at random.
+         * * __prompt:__ _{IMessage|IIsMessage}_ - Initial message to send the user. Message can contain attachments.
          * @param options (Optional) parameters to control the behaviour of the prompt.
          */
         time(session: Session, prompt: TextOrMessageType, options?: IPromptOptions): void;
@@ -3515,17 +3517,17 @@ declare global {
         /**
          * Prompts the user to upload a file attachment.
          * @param session Session object for the current conversation.
-         * @param prompt 
+         * @param prompt
          * * __prompt:__ _{string}_ - Initial message to send the user.
-         * * __prompt:__ _{string[]}_ - Array of possible messages to send user. One will be chosen at random. 
-         * * __prompt:__ _{IMessage|IIsMessage}_ - Initial message to send the user. Message can contain attachments. 
+         * * __prompt:__ _{string[]}_ - Array of possible messages to send user. One will be chosen at random.
+         * * __prompt:__ _{IMessage|IIsMessage}_ - Initial message to send the user. Message can contain attachments.
          * @param options (Optional) parameters to control the behaviour of the prompt.
          */
         attachment(session: Session, prompt: TextOrMessageType, options?: IPromptAttachmentOptions): void;
 
         /**
-         * Prompts the user to disambiguate multiple triggered actions. Should typically be called 
-         * from [UniversalBot.onDisambiguateRoute()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.universalbot#ondisambiguateroute).  
+         * Prompts the user to disambiguate multiple triggered actions. Should typically be called
+         * from [UniversalBot.onDisambiguateRoute()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.universalbot#ondisambiguateroute).
          * @example
          * <pre><code>
          * builder.Prompts.disambiguate(session, "What would you like to cancel?", {
@@ -3535,35 +3537,35 @@ declare global {
          * });
          * </code></pre>
          * @param session Session object for the current conversation.
-         * @param prompt 
+         * @param prompt
          * * __prompt:__ _{string}_ - Initial message to send the user.
-         * * __prompt:__ _{string[]}_ - Array of possible messages to send user. One will be chosen at random. 
-         * * __prompt:__ _{IMessage|IIsMessage}_ - Initial message to send the user. Message can contain attachments. 
+         * * __prompt:__ _{string[]}_ - Array of possible messages to send user. One will be chosen at random.
+         * * __prompt:__ _{IMessage|IIsMessage}_ - Initial message to send the user. Message can contain attachments.
          * @param choices Map of routes to select from. The key is the choice label that will be displayed to the user.
          * @param options (Optional) parameters to control the behaviour of the prompt.
          */
         disambiguate(session: Session, prompt: TextOrMessageType, choices: IDisambiguateChoices, options?: IPromptOptions): void;
 
         /**
-         * Replaces a built-in prompt with a new implementation. This lets you completely customize the 
+         * Replaces a built-in prompt with a new implementation. This lets you completely customize the
          * way a prompt like [builder.Prompts.time()](#time) works globally.
          * @param type The type of built-in prompt that you're customizing.
-         * @param dialog The dialog that you wish to use in place of the default prompt. Be aware that your 
+         * @param dialog The dialog that you wish to use in place of the default prompt. Be aware that your
          * dialog will be registered in the system namespace ('BotBuilder') which can potentially impact
-         * localization and calls to [session.beginDialog()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session#begindialog). For calls to 
-         * beginDialog() from within your custom prompt you'll want to prefix your dialogID's with the 
+         * localization and calls to [session.beginDialog()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session#begindialog). For calls to
+         * beginDialog() from within your custom prompt you'll want to prefix your dialogID's with the
          * namespace of the library you're calling into, typically '*' for the bots default namespace. So
-         * you would use `session.beginDialog('*:help');` to call a "help" dialog from your custom prompt. 
-         */ 
+         * you would use `session.beginDialog('*:help');` to call a "help" dialog from your custom prompt.
+         */
         customize(type: PromptType, dialog: Dialog): IPrompts;
 
         /** __DEPRECATED__ this is no longer used as of v3.8. Use custom prompts instead. */
         configure(options: IPromptsOptions): void;
     }
 }
-    
+
 /**
- * Provides global access to the SDK's built-in prompts. New prompts can be added by simply 
+ * Provides global access to the SDK's built-in prompts. New prompts can be added by simply
  * adding a new function using `builder.Prompts.myPrompt = function (session, prompt, options) { }`.
  * If you are using TypeScript you will first want to add the signature for your prompt to the [IPrompts](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.__global.iprompts)
  * interface using interface decleration merging.
@@ -3573,8 +3575,8 @@ declare global {
  *      interface IPrompts {
  *           myPrompt(session: Session, prompt: string, options?: IPromptOptions): void;
  *      }
- * 
- *       
+ *
+ *
  * }
  * builder.Prompts.disambiguate(session, "What would you like to cancel?", {
  *      "Cancel Item": cancelItemRoute,
@@ -3590,7 +3592,7 @@ export class IntentRecognizerSet extends IntentRecognizer {
     /** Number of recognizers in the set. */
     readonly length: number;
 
-    /**  
+    /**
      * Constructs a new instance of an IntentRecognizerSet.
      * @param options (Optional) options used to initialize the set and control the flow of recognition.
      */
@@ -3607,28 +3609,28 @@ export class IntentRecognizerSet extends IntentRecognizer {
 
     /**
      * Adds a new recognizer plugin to the set.
-     * @param plugin The recognizer to add. 
+     * @param plugin The recognizer to add.
      */
     recognizer(plugin: IIntentRecognizer): IntentDialog;
 }
 
 /** Identifies a users intent and optionally extracts entities from a users utterance. */
 export class IntentDialog extends Dialog {
-    /**  
+    /**
      * Constructs a new instance of an IntentDialog.
      * @param options (Optional) options used to initialize the dialog.
      */
     constructor(options?: IIntentDialogOptions);
 
     /**
-     * Processes messages received from the user. Called by the dialog system. 
+     * Processes messages received from the user. Called by the dialog system.
      * @param session Session object for the current conversation.
      * @param (Optional) recognition results returned from a prior call to the dialogs [recognize()](#recognize) method.
      */
     replyReceived(session: Session, recognizeResult?: IRecognizeResult): void;
 
     /**
-     * Called when the dialog is first loaded after a call to [session.beginDialog()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session#begindialog). This gives the bot an opportunity to process arguments passed to the dialog.  Handlers should always call the `next()` function to continue execution of the dialogs main logic. 
+     * Called when the dialog is first loaded after a call to [session.beginDialog()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session#begindialog). This gives the bot an opportunity to process arguments passed to the dialog.  Handlers should always call the `next()` function to continue execution of the dialogs main logic.
      * @param handler Function to invoke when the dialog begins.
      * @param handler.session Session object for the current conversation.
      * @param handler.args Arguments passed to the dialog in the `session.beginDialog()` call.
@@ -3646,7 +3648,7 @@ export class IntentDialog extends Dialog {
      * @param dialogId
      * * __dialogId:__ _{string} - The ID of a dialog to begin when the intent is matched.
      * * __dialogId:__ _{IDialogWaterfallStep[]}_ - Waterfall of steps to execute when the intent is matched.
-     * * __dialogId:__ _{IDialogWaterfallStep}_ - Single step waterfall to execute when the intent is matched. Calling a built-in prompt or starting a new dialog will result in the current dialog ending upon completion of the child prompt/dialog. 
+     * * __dialogId:__ _{IDialogWaterfallStep}_ - Single step waterfall to execute when the intent is matched. Calling a built-in prompt or starting a new dialog will result in the current dialog ending upon completion of the child prompt/dialog.
      * @param dialogArgs (Optional) arguments to pass the dialog that started when `dialogId` is a _{string}_.
      */
     matches(intent: RegExp|string, dialogId: string|IDialogWaterfallStep[]|IDialogWaterfallStep, dialogArgs?: any): IntentDialog;
@@ -3661,34 +3663,34 @@ export class IntentDialog extends Dialog {
      * @param dialogId
      * * __dialogId:__ _{string} - The ID of a dialog to begin when the intent is matched.
      * * __dialogId:__ _{IDialogWaterfallStep[]}_ - Waterfall of steps to execute when the intent is matched.
-     * * __dialogId:__ _{IDialogWaterfallStep}_ - Single step waterfall to execute when the intent is matched. Calling a built-in prompt or starting a new dialog will result in the current dialog ending upon completion of the child prompt/dialog. 
+     * * __dialogId:__ _{IDialogWaterfallStep}_ - Single step waterfall to execute when the intent is matched. Calling a built-in prompt or starting a new dialog will result in the current dialog ending upon completion of the child prompt/dialog.
      * @param dialogArgs (Optional) arguments to pass the dialog that started when `dialogId` is a _{string}_.
      */
     matchesAny(intent: RegExp[]|string[], dialogId: string|IDialogWaterfallStep[]|IDialogWaterfallStep, dialogArgs?: any): IntentDialog;
 
     /**
      * The default handler to invoke when there are no handlers that match the users intent.
-     * 
+     *
      * > __NOTE:__ The full details of the recognition attempt, including the list of intents & entities detected, will be passed to the [args](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iintentrecognizerresult) of the first waterfall step or dialog that's started.
      * @param dialogId
      * * __dialogId:__ _{string} - The ID of a dialog to begin.
      * * __dialogId:__ _{IDialogWaterfallStep[]}_ - Waterfall of steps to execute.
-     * * __dialogId:__ _{IDialogWaterfallStep}_ - Single step waterfall to execute. Calling a built-in prompt or starting a new dialog will result in the current dialog ending upon completion of the child prompt/dialog. 
+     * * __dialogId:__ _{IDialogWaterfallStep}_ - Single step waterfall to execute. Calling a built-in prompt or starting a new dialog will result in the current dialog ending upon completion of the child prompt/dialog.
      * @param dialogArgs (Optional) arguments to pass the dialog that started when `dialogId` is a _{string}_.
      */
     onDefault(dialogId: string|IDialogWaterfallStep[]|IDialogWaterfallStep, dialogArgs?: any): IntentDialog;
 
     /**
      * Adds a new recognizer plugin to the intent dialog.
-     * @param plugin The recognizer to add. 
+     * @param plugin The recognizer to add.
      */
     recognizer(plugin: IIntentRecognizer): IntentDialog;
 }
 
-/** 
+/**
  * Base class for all core recognizers. Allows conditional execution of a recognizer and post
- * filtering of recognized intents.  Derived class should override the abstract 
- * [onRecognize()](#onrecognize) method. 
+ * filtering of recognized intents.  Derived class should override the abstract
+ * [onRecognize()](#onrecognize) method.
  */
 export abstract class IntentRecognizer implements IIntentRecognizer {
     /**
@@ -3700,8 +3702,8 @@ export abstract class IntentRecognizer implements IIntentRecognizer {
      */
     abstract onRecognize(context: IRecognizeContext, callback: (err: Error, result: IIntentRecognizerResult) => void): void;
 
-    /** 
-     * Attempts to match a users text utterance to an intent. 
+    /**
+     * Attempts to match a users text utterance to an intent.
      * @param context Contextual information for a received message that's being recognized.
      * @param callback Function to invoke with the results of the recognition operation.
      */
@@ -3710,7 +3712,7 @@ export abstract class IntentRecognizer implements IIntentRecognizer {
     /**
      * Registers a function to conditionally enable/disable the recognizer. Multiple handlers can
      * be registered and the new handler will be executed before any other handlers.
-     * @param handler Function called for every message. You should call `callback(null, true)` for every message that should be recognized. 
+     * @param handler Function called for every message. You should call `callback(null, true)` for every message that should be recognized.
      */
     public onEnabled(handler: (context: IRecognizeContext, callback: (err: Error, enabled: boolean) => void) => void): IntentRecognizer;
 
@@ -3722,15 +3724,15 @@ export abstract class IntentRecognizer implements IIntentRecognizer {
     public onFilter(handler: (context: IRecognizeContext, result: IIntentRecognizerResult, callback: (err: Error, result: IIntentRecognizerResult) => void) => void): IntentRecognizer;
 }
 
-/** 
+/**
  * Intent recognizer plugin that detects a users intent using a regular expression. Multiple
- * expressions can be passed in to support recognizing across multiple languages. 
+ * expressions can be passed in to support recognizing across multiple languages.
  */
 export class RegExpRecognizer extends IntentRecognizer {
     /**
      * Constructs a new instance of the recognizer.
      * @param intent The name of the intent to return when the expression is matched.
-     * @param expressions Either an individual expression used for all utterances or a map of per/locale expressions conditionally used depending on the locale of the utterance. 
+     * @param expressions Either an individual expression used for all utterances or a map of per/locale expressions conditionally used depending on the locale of the utterance.
      */
     constructor(intent: string, expressions: RegExp|IRegExpMap);
 
@@ -3738,15 +3740,15 @@ export class RegExpRecognizer extends IntentRecognizer {
     onRecognize(context: IRecognizeContext, callback: (err: Error, result: IIntentRecognizerResult) => void): void;
 }
 
-/** 
- * Version of the [RegExpRecognizer](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.regexprecognizer) 
+/**
+ * Version of the [RegExpRecognizer](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.regexprecognizer)
  * that uses the frameworks localization system to retrieve a localized regular expression.
  * The lookup key in the index.json file should be provided and upon receiving a message for
- * a new locale, the recognizer will retrieve the localized expression and a new case insensitive 
- * `RegExp` will be created and used to recognize the intent. 
- * 
+ * a new locale, the recognizer will retrieve the localized expression and a new case insensitive
+ * `RegExp` will be created and used to recognize the intent.
+ *
  * Libraries can use this feature to let a bot override their default matching expressions. just
- * create instances of the recognizer using the namespace of your library and bot developers can 
+ * create instances of the recognizer using the namespace of your library and bot developers can
  * customize your matching expressions by using a `<namespace>.json` file in their locale directory.
  */
 export class LocalizedRegExpRecognizer extends IntentRecognizer {
@@ -3754,7 +3756,7 @@ export class LocalizedRegExpRecognizer extends IntentRecognizer {
      * Constructs a new instance of the recognizer.
      * @param intent The name of the intent to return when the expression is matched.
      * @param key Key for the expression in the `index.json` or `<namespace>.json` file.
-     * @param namespace (Optional) library namespace to lookup `key` from. The expression should be a string in the `<namespace>.json` locale file. 
+     * @param namespace (Optional) library namespace to lookup `key` from. The expression should be a string in the `<namespace>.json` locale file.
      */
     constructor(intent: string, key: string, namespace?: string);
 
@@ -3764,13 +3766,13 @@ export class LocalizedRegExpRecognizer extends IntentRecognizer {
 
 /**
  * Intent recognizer plugin that detects a users intent using Microsofts [Language Understanding Intelligent Service (LUIS)](https://luis.ai)
- * The service URLs for multiple LUIS models (apps) can be passed in to support recognition 
- * across multiple languages. 
+ * The service URLs for multiple LUIS models (apps) can be passed in to support recognition
+ * across multiple languages.
  */
 export class LuisRecognizer extends IntentRecognizer {
     /**
      * Constructs a new instance of the recognizer.
-     * @param models Either an individual LUIS model used for all utterances or a map of per/locale models conditionally used depending on the locale of the utterance. 
+     * @param models Either an individual LUIS model used for all utterances or a map of per/locale models conditionally used depending on the locale of the utterance.
      */
     constructor(models: string|ILuisModelMap);
 
@@ -3799,7 +3801,7 @@ export class EntityRecognizer {
      * @param type Type of entity to find.
      */
     static findEntity(entities: IEntity[], type: string): IEntity;
-    
+
     /**
      * Finds all occurrences of a specific entity type within a set.
      * @param entities Set of entities to search over.
@@ -3809,17 +3811,17 @@ export class EntityRecognizer {
 
     /**
      * Parses a date from either a users text utterance or a set of entities.
-     * @param value 
+     * @param value
      * * __value:__ _{string}_ - Text utterance to parse. The utterance is parsed using the [Chrono](http://wanasit.github.io/pages/chrono/) library.
      * * __value:__ _{IEntity[]}_ - Set of entities to resolve.
      * @returns A valid Date object if the user spoke a time otherwise _null_.
-     */   
+     */
     static parseTime(value: string | IEntity[]): Date;
 
     /**
      * Calculates a Date from a set of datetime entities.
      * @param entities List of entities to extract date from.
-     * @returns The successfully calculated Date or _null_ if a date couldn't be determined. 
+     * @returns The successfully calculated Date or _null_ if a date couldn't be determined.
      */
     static resolveTime(entities: IEntity[]): Date;
 
@@ -3827,32 +3829,32 @@ export class EntityRecognizer {
      * Recognizes a time from a users utterance. The utterance is parsed using the [Chrono](http://wanasit.github.io/pages/chrono/) library.
      * @param utterance Text utterance to parse.
      * @param refDate (Optional) reference date used to calculate the final date.
-     * @returns An entity containing the resolved date if successful or _null_ if a date couldn't be determined. 
+     * @returns An entity containing the resolved date if successful or _null_ if a date couldn't be determined.
      */
     static recognizeTime(utterance: string, refDate?: Date): IEntity;
 
     /**
      * Parses a number from either a users text utterance or a set of entities.
      * @param value
-     * * __value:__ _{string}_ - Text utterance to parse. 
+     * * __value:__ _{string}_ - Text utterance to parse.
      * * __value:__ _{IEntity[]}_ - Set of entities to resolve.
-     * @returns A valid number otherwise _Number.NaN_. 
+     * @returns A valid number otherwise _Number.NaN_.
      */
     static parseNumber(value: string | IEntity[]): number;
 
     /**
      * Parses a boolean from a users utterance.
      * @param value Text utterance to parse.
-     * @returns A valid boolean otherwise _undefined_. 
+     * @returns A valid boolean otherwise _undefined_.
      */
     static parseBoolean(value: string): boolean;
-    
+
     /**
      * Finds the best match for a users utterance given a list of choices.
-     * @param choices 
-     * * __choices:__ _{string}_ - Pipe ('|') delimited list of values to compare against the users utterance. 
-     * * __choices:__ _{Object}_ - Object used to generate the list of choices. The objects field names will be used to build the list of choices. 
-     * * __choices:__ _{string[]}_ - Array of strings to compare against the users utterance. 
+     * @param choices
+     * * __choices:__ _{string}_ - Pipe ('|') delimited list of values to compare against the users utterance.
+     * * __choices:__ _{Object}_ - Object used to generate the list of choices. The objects field names will be used to build the list of choices.
+     * * __choices:__ _{string[]}_ - Array of strings to compare against the users utterance.
      * @param utterance Text utterance to parse.
      * @param threshold (Optional) minimum score needed for a match to be considered. The default value is 0.6.
      */
@@ -3860,10 +3862,10 @@ export class EntityRecognizer {
 
     /**
      * Finds all possible matches for a users utterance given a list of choices.
-     * @param choices 
-     * * __choices:__ _{string}_ - Pipe ('|') delimited list of values to compare against the users utterance. 
-     * * __choices:__ _{Object}_ - Object used to generate the list of choices. The objects field names will be used to build the list of choices. 
-     * * __choices:__ _{string[]}_ - Array of strings to compare against the users utterance. 
+     * @param choices
+     * * __choices:__ _{string}_ - Pipe ('|') delimited list of values to compare against the users utterance.
+     * * __choices:__ _{Object}_ - Object used to generate the list of choices. The objects field names will be used to build the list of choices.
+     * * __choices:__ _{string[]}_ - Array of strings to compare against the users utterance.
      * @param utterance Text utterance to parse.
      * @param threshold (Optional) minimum score needed for a match to be considered. The default value is 0.6.
      */
@@ -3871,40 +3873,40 @@ export class EntityRecognizer {
 
     /**
      * Converts a set of choices into an expanded array.
-     * @param choices 
-     * * __choices:__ _{string}_ - Pipe ('|') delimited list of values. 
-     * * __choices:__ _{Object}_ - Object used to generate the list of choices. The objects field names will be used to build the list of choices. 
-     * * __choices:__ _{string[]}_ - Array of strings. This will just be echoed back as the output. 
+     * @param choices
+     * * __choices:__ _{string}_ - Pipe ('|') delimited list of values.
+     * * __choices:__ _{Object}_ - Object used to generate the list of choices. The objects field names will be used to build the list of choices.
+     * * __choices:__ _{string[]}_ - Array of strings. This will just be echoed back as the output.
      */
     static expandChoices(choices: string | Object | string[]): string[];
 }
 
 /**
- * Allows for the creation of custom dialogs that are based on a simple closure. This is useful for 
- * cases where you want a dynamic conversation flow or you have a situation that just doesn’t map 
+ * Allows for the creation of custom dialogs that are based on a simple closure. This is useful for
+ * cases where you want a dynamic conversation flow or you have a situation that just doesn’t map
  * very well to using a waterfall.  The things to keep in mind:
  * * Your dialogs closure is can get called in two different contexts that you potentially need to
- *   test for. It will get called as expected when the user send your dialog a message but if you 
- *   call another prompt or dialog from your closure it will get called a second time with the 
- *   results from the prompt/dialog. You can typically test for this second case by checking for the 
- *   existant of an `args.resumed` property. It's important to avoid getting yourself into an 
+ *   test for. It will get called as expected when the user send your dialog a message but if you
+ *   call another prompt or dialog from your closure it will get called a second time with the
+ *   results from the prompt/dialog. You can typically test for this second case by checking for the
+ *   existant of an `args.resumed` property. It's important to avoid getting yourself into an
  *   infinite loop which can be easy to do.
- * * Unlike a waterfall your dialog will not automatically end. It will remain the active dialog 
- *   until you call [session.endDialog()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session.html#enddialog). 
+ * * Unlike a waterfall your dialog will not automatically end. It will remain the active dialog
+ *   until you call [session.endDialog()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session.html#enddialog).
  */
 export class SimpleDialog extends Dialog {
     /**
      * Creates a new custom dialog based on a simple closure.
-     * @param handler The function closure for your dialog. 
+     * @param handler The function closure for your dialog.
      * @param handler.session Session object for the current conversation.
-     * @param handler.args 
+     * @param handler.args
      * * __args:__ _{any}_ - For the first call to the handler this will be either `null` or the value of any arguments passed to [Session.beginDialog()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.session.html#begindialog).
      * * __args:__ _{IDialogResult}_ - If the handler takes an action that results in a new dialog being started those results will be returned via subsequent calls to the handler.
      */
     constructor(handler: (session: Session, args?: any | IDialogResult<any>) => void);
-    
+
     /**
-     * Processes messages received from the user. Called by the dialog system. 
+     * Processes messages received from the user. Called by the dialog system.
      * @param session Session object for the current conversation.
      */
     replyReceived(session: Session): void;
@@ -3917,9 +3919,9 @@ export class WaterfallDialog extends Dialog {
      * @param steps Sequence of function(s) that should be called in order.
      */
     constructor(steps: IDialogWaterfallStep|IDialogWaterfallStep[]);
-    
+
     /**
-     * Processes messages received from the user. Called by the dialog system. 
+     * Processes messages received from the user. Called by the dialog system.
      * @param session Session object for the current conversation.
      */
     replyReceived(session: Session): void;
@@ -3927,9 +3929,9 @@ export class WaterfallDialog extends Dialog {
     /**
      * Registers a handler that will be called before every step of the waterfall. The handlers
      * `next()` function will execute either the next handler in the chain or the waterfall step
-     * itself.  This handler lets a developer skip steps and process the args being passed to 
+     * itself.  This handler lets a developer skip steps and process the args being passed to
      * the next step.
-     * 
+     *
      * Multiple handlers may be registered and the handler being registered will be executed before
      * any other handlers in the chain.
      * @param handler Function to invoke in-between each waterfall step.
@@ -3937,15 +3939,15 @@ export class WaterfallDialog extends Dialog {
     onBeforeStep(handler: (session: Session, step: number, args: any, next: (step: number, args: any) => void) => void): WaterfallDialog;
 
     /**
-     * Creates a function that can drive a waterfall. Everytime the function is called it will drive 
-     * the waterfall forward by invoking the next step of the waterfall. The function uses 
-     * `session.dialogData` to hold the waterfalls current step. 
-     * 
-     * To drive the waterfall forward, the `args` param passed to the handler should have 
-     * `args.resumed = builder.ResumeReason.completed`. Once the end of the waterfall is reached 
+     * Creates a function that can drive a waterfall. Everytime the function is called it will drive
+     * the waterfall forward by invoking the next step of the waterfall. The function uses
+     * `session.dialogData` to hold the waterfalls current step.
+     *
+     * To drive the waterfall forward, the `args` param passed to the handler should have
+     * `args.resumed = builder.ResumeReason.completed`. Once the end of the waterfall is reached
      * it will automatically call `session.endDialogWithResult(args)` returning the passed in args.
      * If the `args` param is missing the `resumed` field the waterfall will simply start over
-     * calling the first step. 
+     * calling the first step.
      * @param steps Waterfall steps to execute.
      */
     static createHandler(steps: IDialogWaterfallStep[]): (session: Session, args?: any) => void;
@@ -3955,17 +3957,17 @@ export class WaterfallDialog extends Dialog {
 export class MemoryBotStorage implements IBotStorage {
     /** Returns data from memory for the given context. */
     getData(context: IBotStorageContext, callback: (err: Error, data: IBotStorageData) => void): void;
-    
+
     /** Saves data to memory for the given context. */
     saveData(context: IBotStorageContext, data: IBotStorageData, callback?: (err: Error) => void): void;
-    
+
     /** Deletes in-memory data for the given context. */
     deleteData(context: IBotStorageContext): void;
 }
 
 /** Manages your bots conversations with users across multiple channels. */
 export class UniversalBot extends Library  {
-    /** 
+    /**
      * Creates a new instance of the UniversalBot.
      * @param connector (Optional) the default connector to use for requests. If there's not a more specific connector registered for a channel then this connector will be used./**
      * @param defaultDialog (Optional) default handler of received messages. This can either be an individual function or a waterfall sequence.
@@ -3982,30 +3984,30 @@ export class UniversalBot extends Library  {
 
     /**
      * Registers an event listener. The bot will emit its own events as it processes incoming and outgoing messages. It will also forward activity related events emitted from the connector, giving you one place to listen for all activity from your bot. The flow of events from the bot is as follows:
-     * 
+     *
      * #### Message Received
-     * When the bot receives a new message it will emit the following events in order: 
-     * 
+     * When the bot receives a new message it will emit the following events in order:
+     *
      * > lookupUser -> receive -> incoming -> getStorageData -> routing
-     * 
-     * Any [receive middleware](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.imiddlewaremap#receive) that's been installed will be executed between the 'receive' and 'incoming' events. After the 'routing' event is emitted any 
-     * [botbuilder middleware](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.imiddlewaremap#botbuilder) will be executed prior to dispatching the message to the bots active dialog.  
-     * 
+     *
+     * Any [receive middleware](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.imiddlewaremap#receive) that's been installed will be executed between the 'receive' and 'incoming' events. After the 'routing' event is emitted any
+     * [botbuilder middleware](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.imiddlewaremap#botbuilder) will be executed prior to dispatching the message to the bots active dialog.
+     *
      * #### Connector Activity Received
      * Connectors can emit activity events to signal things like a user is typing or that they friended a bot. These activities get routed through middleware like messages but they are not routed through the bots dialog system.  They are only ever emitted as events.
-     * 
-     * The flow of connector events is: 
-     * 
+     *
+     * The flow of connector events is:
+     *
      * > lookupUser -> receive -> (activity)
-     * 
+     *
      * #### Message sent
      * Bots can send multiple messages so the session will batch up all outgoing message and then save the bots current state before delivering the sent messages.  You'll see a single 'saveStorageData' event emitted and then for every outgoing message in the batch you'll see the following
-     * sequence of events: 
-     * 
+     * sequence of events:
+     *
      * > send -> outgoing
-     * 
-     * Any [send middleware](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.imiddlewaremap#send) that's been installed will be executed between the 'send' and 'outgoing' events. 
-     *  
+     *
+     * Any [send middleware](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.imiddlewaremap#send) that's been installed will be executed between the 'send' and 'outgoing' events.
+     *
      * @param event Name of the event. Bot and connector specific event types:
      * #### Bot Events
      * - __error:__ An error occured. Passed a JavaScript `Error` object.
@@ -4017,79 +4019,79 @@ export class UniversalBot extends Library  {
      * - __outgoing:__ An outgoing message has just been sent through middleware and is about to be delivered to the users chat client.
      * - __getStorageData:__ The sessions persisted state data is being loaded from storage. Passed an [IBotStorageContext](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.ibotstoragecontext.html) object.
      * - __saveStorageData:__ The sessions persisted state data is being written to storage. Passed an [IBotStorageContext](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.ibotstoragecontext.html) object.
-     * 
+     *
      * #### ChatConnector Events
      * - __conversationUpdate:__ Your bot was added to a conversation or other conversation metadata changed. Passed an [IConversationUpdate](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iconversationupdate.html) object.
      * - __contactRelationUpdate:__ The bot was added to or removed from a user's contact list. Passed an [IContactRelationUpdate](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.icontactrelationupdate.html) object.
      * - __typing:__ The user or bot on the other end of the conversation is typing. Passed an [IEvent](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.ievent.html) object.
-     * 
+     *
      * @param listener Function to invoke.
-     * @param listener.data The data for the event. Consult the list above for specific types of data you can expect to receive.  
+     * @param listener.data The data for the event. Consult the list above for specific types of data you can expect to receive.
      */
     on(event: string, listener: (data: any) => void): void;
 
-    /** 
-     * Sets a setting on the bot. 
+    /**
+     * Sets a setting on the bot.
      * @param name Name of the property to set. Valid names are properties on [IUniversalBotSettings](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iuniversalbotsettings.html).
      * @param value The value to assign to the setting.
      */
     set(name: string, value: any): UniversalBot;
 
-    /** 
+    /**
      * Returns the current value of a setting.
      * @param name Name of the property to return. Valid names are properties on [IUniversalBotSettings](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iuniversalbotsettings.html).
      */
     get(name: string): any;
 
-    /** 
-     * Registers or returns a connector for a specific channel. 
+    /**
+     * Registers or returns a connector for a specific channel.
      * @param channelId Unique ID of the channel. Use a channelId of '*' to reference the default connector.
-     * @param connector (Optional) connector to register. If ommited the connector for __channelId__ will be returned. 
-     */    
+     * @param connector (Optional) connector to register. If ommited the connector for __channelId__ will be returned.
+     */
     connector(channelId: string, connector?: IConnector): IConnector;
-    
-    /** 
-     * Installs middleware for the bot. Middleware lets you intercept incoming and outgoing events/messages. 
+
+    /**
+     * Installs middleware for the bot. Middleware lets you intercept incoming and outgoing events/messages.
      * @param args One or more sets of middleware hooks to install.
      */
     use(...args: IMiddlewareMap[]): UniversalBot;
-    
-    /** 
+
+    /**
      * Called when a new event is received. This can be called manually to mimic the bot receiving a message from the user.
      * @param events Event or (array of events) received.
-     * @param done (Optional) function to invoke once the operation is completed. 
+     * @param done (Optional) function to invoke once the operation is completed.
      */
     receive(events: IEvent|IEvent[], done?: (err: Error) => void): void;
- 
-    /** 
+
+    /**
      * Proactively starts a new dialog with the user. Any current conversation between the bot and user will be replaced with a new dialog stack.
      * @param address Address of the user to start a new conversation with. This should be saved during a previous conversation with the user. Any existing conversation or dialog will be immediately terminated.
      * @param dialogId ID of the dialog to begin.
      * @param dialogArgs (Optional) arguments to pass to dialog.
-     * @param done (Optional) function to invoke once the operation is completed. 
+     * @param done (Optional) function to invoke once the operation is completed.
      */
     beginDialog(address: IAddress, dialogId: string, dialogArgs?: any, done?: (err: Error) => void): void;
 
-    /** 
+    /**
      * Sends a message to the user without disrupting the current conversations dialog stack.
      * @param messages The message (or array of messages) to send the user.
-     * @param done (Optional) function to invoke once the operation is completed. 
+     * @param done (Optional) function to invoke once the operation is completed.
      * @param done.err Any error that occured during the send.
      * @param done.addresses An array of address objects returned for each individual message within the batch. These address objects contain the ID of the posted messages so can be used to update or delete a message in the future.
      */
     send(messages: IIsMessage|IMessage|IMessage[], done?: (err: Error, addresses?: IAddress[]) => void): void;
 
-    /** 
+    /**
      * Returns information about when the last turn between the user and a bot occured. This can be called
      * before [beginDialog](#begindialog) to determine if the user is currently in a conversation with the
-     * bot. 
+     * bot.
      * @param address Address of the user to lookup. This should be saved during a previous conversation with the user.
      * @param callback Function to invoke with the results of the query.
      */
     isInConversation(address: IAddress, callback: (err: Error, lastAccess: Date) => void): void;
 
-    /** 
-     * Loads a session object for an arbitrary address. 
+    /**
+     * Loads a session object for an arbitrary address.
      * @param address Address of the user/session to load. This should be saved during a previous conversation with the user.
      * @param callback Function to invoke with the loaded session.
      */
@@ -4097,7 +4099,7 @@ export class UniversalBot extends Library  {
 
     /**
      * Replaces the bots default route disambiguation logic with a custom implementation.
-     * @param handler Function that will be invoked with the candidate routes to dispatch an incoming message to. 
+     * @param handler Function that will be invoked with the candidate routes to dispatch an incoming message to.
      */
     onDisambiguateRoute(handler: IDisambiguateRouteHandler): void;
 }
@@ -4105,9 +4107,9 @@ export class UniversalBot extends Library  {
 /** Connects a UniversalBot to multiple channels via the Bot Framework. */
 export class ChatConnector implements IConnector, IBotStorage {
 
-    /** 
+    /**
      * Creates a new instnace of the ChatConnector.
-     * @param settings (Optional) config params that let you specify the bots App ID & Password you were assigned in the Bot Frameworks developer portal. 
+     * @param settings (Optional) config params that let you specify the bots App ID & Password you were assigned in the Bot Frameworks developer portal.
      */
     constructor(settings?: IChatConnectorSettings);
 
@@ -4119,7 +4121,7 @@ export class ChatConnector implements IConnector, IBotStorage {
 
     /** Called by the UniversalBot at registration time to register a handler for receiving incoming events from a channel. */
     onEvent(handler: (events: IEvent[], callback?: (err: Error) => void) => void): void;
-    
+
     /** Called by the UniversalBot to deliver outgoing messages to a user. */
     send(messages: IMessage[], done: (err: Error, addresses?: IAddress[]) => void): void;
 
@@ -4141,10 +4143,10 @@ export class ChatConnector implements IConnector, IBotStorage {
     /** Gets the current access token for the bot. */
     getAccessToken(callback: (err: Error, accessToken: string) => void): void;
 
-    /** 
+    /**
      * Called after the connector receives, authenticates, and prepares an event. Derived classes
-     * can override this to filter out incoming events before they're dispatched to the bot. 
-     * Calling `super.onDispatchMessage(event, callback)` will perform the connectors default 
+     * can override this to filter out incoming events before they're dispatched to the bot.
+     * Calling `super.onDispatchMessage(event, callback)` will perform the connectors default
      * logic.
      * @param events Array of 0 or more events to dispatch.
      * @param callback Function that will be called after all events have been dispatched.
@@ -4162,13 +4164,16 @@ export class ConsoleConnector implements IConnector {
 
     /** Sends a message through the connector. */
     processMessage(line: string): ConsoleConnector;
-    
+
+    /** Sends a event through the connector. */
+    processEvent(event: IEvent): ConsoleConnector;
+
     /** Used to register a handler for receiving incoming invoke events. */
     onInvoke(handler: (event: IEvent, cb?: (err: Error, body: any, status?: number) => void) => void): void;
 
     /** Called by the UniversalBot at registration time to register a handler for receiving incoming events from a channel. */
     onEvent(handler: (events: IEvent[], callback?: (err: Error) => void) => void): void;
-    
+
     /** Called by the UniversalBot to deliver outgoing messages to a user. */
     send(messages: IMessage[], callback: (err: Error, addresses?: IAddress[]) => void): void;
 
@@ -4177,19 +4182,19 @@ export class ConsoleConnector implements IConnector {
 }
 
 export class Middleware {
-    /** 
+    /**
      * Installs a piece of middleware that manages the versioning of a bots dialogs.
-     * @param options Settings to configure the bahviour of the installed middleware. 
+     * @param options Settings to configure the bahviour of the installed middleware.
      */
     static dialogVersion(options: IDialogVersionOptions): IMiddlewareMap;
 
-    /** 
-     * Adds a first run experience to a bot. The middleware uses Session.userData to store the latest version of the first run dialog the user has been through. Incrementing the version number can force users to run back through either the full or a partial first run dialog. 
-     * @param options Settings to configure the bahviour of the installed middleware. 
+    /**
+     * Adds a first run experience to a bot. The middleware uses Session.userData to store the latest version of the first run dialog the user has been through. Incrementing the version number can force users to run back through either the full or a partial first run dialog.
+     * @param options Settings to configure the bahviour of the installed middleware.
      */
     static firstRun(options: IFirstRunOptions): IMiddlewareMap;
 
-    /** 
+    /**
      * Installs a piece of middleware that will always send an initial typing indication to the user.
      * This is useful because it lets you send the typing indication before any LUIS models are called.
      * The typing indicator will only stay valid for a few seconds so if you're performing any long running


### PR DESCRIPTION
I'm adding the `processEvent` signature that is missing from a previous PR I did. I removed a lot of whitespaces from the definition file too. But the only real change is the addition of `processEvent(event: IEvent): ConsoleConnector;` to the `ConsoleConnector` class.

CC: @Stevenic 