### PR TITLE
[.NET SDK] Adding the IgnoreField attribute to the FormFlow #3845

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder.FormFlow.Json/FormBuilderJson.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.FormFlow.Json/FormBuilderJson.cs
@@ -391,7 +391,7 @@ namespace Microsoft.Bot.Builder.FormFlow.Json
         private void FieldPaths(Type type, string path, List<string> paths)
         {
             var newPath = (path == "" ? path : path + ".");
-            foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance))
+            foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance).Where(f => !f.IsDefined(typeof(IgnoreFieldAttribute))))
             {
                 TypePaths(field.FieldType, newPath + field.Name, paths);
             }

--- a/CSharp/Library/Microsoft.Bot.Builder/FormFlow/Attributes.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/FormFlow/Attributes.cs
@@ -667,6 +667,23 @@ namespace Microsoft.Bot.Builder.FormFlow
             Pattern = pattern;
         }
     }
+
+    /// <summary>
+    /// Define a field or property as excluded.
+    /// </summary>
+    /// <remarks>
+    /// The ignored field is a field that is excluded from the list of fields.
+    /// </remarks>
+    [Serializable]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class IgnoreFieldAttribute : Attribute
+    {
+        /// <summary>
+        /// Mark a field or property as excluded.
+        /// </summary>
+        public IgnoreFieldAttribute()
+        { }
+    }
 }
 
 namespace Microsoft.Bot.Builder.FormFlow.Advanced

--- a/CSharp/Library/Microsoft.Bot.Builder/FormFlow/FormBuilder.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/FormFlow/FormBuilder.cs
@@ -454,7 +454,7 @@ namespace Microsoft.Bot.Builder.FormFlow
         private void FieldPaths(Type type, string path, List<string> paths)
         {
             var newPath = (path == "" ? path : path + ".");
-            foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance))
+            foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance).Where(f => !f.IsDefined(typeof(IgnoreFieldAttribute))))
             {
                 TypePaths(field.FieldType, newPath + field.Name, paths);
             }


### PR DESCRIPTION
IgnoreField attribute for convenient and quick exclusion of extra fields from the class when using FormFlow