### PR TITLE
add next fix to ChatConnector.dispatch()

### DIFF
--- a/Node/core/lib/bots/ChatConnector.js
+++ b/Node/core/lib/bots/ChatConnector.js
@@ -445,6 +445,7 @@ var ChatConnector = (function () {
         }
     };
     ChatConnector.prototype.dispatch = function (msg, res, next) {
+        next = next || function () { };
         try {
             this.prepIncomingMessage(msg);
             logger.info(msg, 'ChatConnector: message received.');

--- a/Node/core/src/bots/ChatConnector.ts
+++ b/Node/core/src/bots/ChatConnector.ts
@@ -549,6 +549,7 @@ export class ChatConnector implements IConnector, IBotStorage {
 
     private dispatch(msg: IMessage, res: IWebResponse, next: Function) {
         // Dispatch message/activity
+        next = next || function () {};
         try {
             this.prepIncomingMessage(msg);
             logger.info(msg, 'ChatConnector: message received.');


### PR DESCRIPTION
Add fix to `ChatConnector.dispatch()` regarding `next`.
- If `next` is falsey, `next` will default to `function() { };`
- This covers cases where `next` is not provided, e.g. when not using restify to serve a bot.