### PR TITLE
[.NET SDK] Add support for BingSpellCheckSubscriptionKey to LuisOptions, LuisSevice, LuisModel

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisModel.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisModel.cs
@@ -155,11 +155,17 @@ namespace Microsoft.Bot.Builder.Luis
         /// </summary>
         public bool Verbose { get { return Options.Verbose.Value; } set { Options.Verbose = value; } }
 
+        /// <summary>
+        /// The Bing Spell Check subscription key.
+        /// </summary>
+        public string BingSpellCheckSubscriptionKey { get { return Options.BingSpellCheckSubscriptionKey; } set { Options.BingSpellCheckSubscriptionKey = value;  } }
+
         bool? ILuisOptions.Log { get; set; }
         bool? ILuisOptions.SpellCheck { get; set; }
         bool? ILuisOptions.Staging { get; set; }
         double? ILuisOptions.TimezoneOffset { get; set; }
         bool? ILuisOptions.Verbose { get; set; }
+        string ILuisOptions.BingSpellCheckSubscriptionKey { get; set; }
 
         public static Uri UriFor(LuisApiVersion apiVersion, string domain = null)
         {

--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisOptions.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisOptions.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Bot.Builder.Luis
             if (source.Staging.HasValue) target.Staging = source.Staging.Value;
             if (source.TimezoneOffset.HasValue) target.TimezoneOffset = source.TimezoneOffset.Value;
             if (source.Verbose.HasValue) target.Verbose = source.Verbose.Value;
-            if (source.BingSpellCheckSubscriptionKey != null) target.BingSpellCheckSubscriptionKey = source.BingSpellCheckSubscriptionKey;
+            if (!string.IsNullOrWhiteSpace(source.BingSpellCheckSubscriptionKey)) target.BingSpellCheckSubscriptionKey = source.BingSpellCheckSubscriptionKey;
         }
     }
 }

--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisOptions.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisOptions.cs
@@ -63,6 +63,11 @@ namespace Microsoft.Bot.Builder.Luis
         /// The verbose flag.
         /// </summary>
         bool? Verbose { get; set; }
+
+        /// <summary>
+        /// The Bing Spell Check subscription key.
+        /// </summary>
+        string BingSpellCheckSubscriptionKey { get; set; }
     }
 
     public static partial class Extensions
@@ -74,6 +79,7 @@ namespace Microsoft.Bot.Builder.Luis
             if (source.Staging.HasValue) target.Staging = source.Staging.Value;
             if (source.TimezoneOffset.HasValue) target.TimezoneOffset = source.TimezoneOffset.Value;
             if (source.Verbose.HasValue) target.Verbose = source.Verbose.Value;
+            if (source.BingSpellCheckSubscriptionKey != null) target.BingSpellCheckSubscriptionKey = source.BingSpellCheckSubscriptionKey;
         }
     }
 }

--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisService.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisService.cs
@@ -79,6 +79,11 @@ namespace Microsoft.Bot.Builder.Luis
         public bool? Verbose { get; set; }
 
         /// <summary>
+        /// The Bing Spell Check subscription key.
+        /// </summary>
+        public string BingSpellCheckSubscriptionKey { get; set; }
+
+        /// <summary>
         /// Any extra query parameters for the URL.
         /// </summary>
         public string ExtraParameters { get; set; }
@@ -162,6 +167,10 @@ namespace Microsoft.Bot.Builder.Luis
             if (Verbose != null)
             {
                 queryParameters.Add($"verbose={Uri.EscapeDataString(Convert.ToString(Verbose))}");
+            }
+            if (BingSpellCheckSubscriptionKey != null)
+            {
+                queryParameters.Add($"bing-spell-check-subscription-key={Uri.EscapeDataString(BingSpellCheckSubscriptionKey)}");
             }
 #pragma warning disable CS0618
             if (ContextId != null)

--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisService.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisService.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Bot.Builder.Luis
             {
                 queryParameters.Add($"verbose={Uri.EscapeDataString(Convert.ToString(Verbose))}");
             }
-            if (BingSpellCheckSubscriptionKey != null)
+            if (!string.IsNullOrWhiteSpace(BingSpellCheckSubscriptionKey))
             {
                 queryParameters.Add($"bing-spell-check-subscription-key={Uri.EscapeDataString(BingSpellCheckSubscriptionKey)}");
             }


### PR DESCRIPTION
Per LUIS Runtime Swagger File, [Line #78](https://github.com/Azure/azure-rest-api-specs/blob/current/specification/cognitiveservices/data-plane/LUIS/Runtime/v2.0/LUIS-Runtime.json#L78)

```js
{
  "name": "bing-spell-check-subscription-key",
  "in": "query",
  "description": "The subscription key to use when enabling bing spell check",
  "type": "string"
}
```