### PR TITLE
[.NET SDK] ReplayTranscript constructor ignores the "header" argument

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder.History/ReplayTranscript.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.History/ReplayTranscript.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Bot.Builder.History
         public ReplayTranscript(IBotToUser botToUser, Func<IActivity, string> header = null)
         {
             _botToUser = botToUser;
+            _header = header;
             if (_header == null)
             {
                 _header = (activity) => $"({activity.From.Name} {activity.Timestamp:g})";


### PR DESCRIPTION
ReplayTranscript constructor ignores the "header" argument, because it does not assign the argument to the corresponding field, and it uses the default "header" function.