### PR TITLE
Add startReplyChain to UniversalBot and IConnector

### DIFF
--- a/Node/core/lib/botbuilder.d.ts
+++ b/Node/core/lib/botbuilder.d.ts
@@ -1356,6 +1356,15 @@ export interface IConnector {
     send(messages: IMessage[], callback: (err: Error, addresses?: IAddress[]) => void): void;
 
     /**
+     * Send a message to the user and in a newly started reply chain address in channel
+     * @param messages Array of message(s) to send the user.
+     * @param callback Function to invoke once the operation is completed.
+     * @param callback.err Any error that occurred during the send.
+     * @param callback.addresses An array of address objects returned for each individual message within the batch. These address objects contain the ID of the posted messages so can be used to update or delete a message in the future.
+     */
+    startReplyChain?(messages: IMessage[], callback: (err: Error, addresses?: IAddress[]) => void): void;
+
+    /**
      * Called when a UniversalBot wants to start a new proactive conversation with a user. The
      * connector should return an address with a properly formated [IAddress.conversation](/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iaddress#conversation)
      * field. This will typically be called when you call [UniversalBot.beginDialog()](/en-us/node/builder/chat-reference/classes/_botbuilder_d_.universalbot#begindialog)
@@ -4083,6 +4092,15 @@ export class UniversalBot extends Library  {
      * @param done.addresses An array of address objects returned for each individual message within the batch. These address objects contain the ID of the posted messages so can be used to update or delete a message in the future.
      */
     send(messages: IIsMessage|IMessage|IMessage[], done?: (err: Error, addresses?: IAddress[]) => void): void;
+
+    /**
+     * Send a message to the user and in a newly started reply chain address in channel
+     * @param messages The message (or array of messages) to send the user.
+     * @param done (Optional) function to invoke once the operation is completed.
+     * @param done.err Any error that occured during the send.
+     * @param done.addresses An array of address objects returned for each individual message within the batch. These address objects contain the ID of the posted messages so can be used to update or delete a message in the future.
+     */
+    startReplyChain(messages: IIsMessage|IMessage|IMessage[], done?: (err: Error, addresses?: IAddress[]) => void): void;
 
     /**
      * Returns information about when the last turn between the user and a bot occured. This can be called

--- a/Node/core/package-lock.json
+++ b/Node/core/package-lock.json
@@ -2,7 +2,6 @@
   "name": "botbuilder",
   "version": "3.14.0",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "@types/url-join": {
       "version": "0.8.2",

--- a/Node/core/package.json
+++ b/Node/core/package.json
@@ -34,6 +34,7 @@
     "mocha": "^2.4.5"
   },
   "scripts": {
+    "build": "tsc --project src/tsconfig.json",
     "test": "mocha tests/*.js"
   }
 }


### PR DESCRIPTION
At the moment the following connectors implement the startReplyChain:

- botbuilder-teams
  (https://github.com/OfficeDev/BotBuilder-MicrosoftTeams)
- botbuilder-slack (https://github.com/suttna/botbuilder-slack)

On both cases, the current solution at the connector level breaks the
usage of middlewares. In both cases, the "send" middleware is not called
when sending a message using the startReplyChain api.

We want to standarize the startReplyChain since a lot of clients support
it and is very useful operation. The idea would be to get this merged so
that both previously mentioned libraries can update the implementation
to match the new signature.