### PR TITLE
[Node.js SDK] Add onBeforeBegin to WaterfallDialog

### DIFF
--- a/Node/core/lib/botbuilder.d.ts
+++ b/Node/core/lib/botbuilder.d.ts
@@ -3930,6 +3930,14 @@ export class WaterfallDialog extends Dialog {
     replyReceived(session: Session): void;
 
     /**
+     * Registers a handler that will be called before the first waterfall step. This handler lets a
+     * developer skip the entire dialog and process the args being passed to the first step of it.
+     *
+     * @param handler Function to invoke before the first waterfall step.
+     */
+    onBeforeBegin(handler: (session: Session, args: any, next: (args: any) => void) => void): WaterfallDialog;
+
+    /**
      * Registers a handler that will be called before every step of the waterfall. The handlers
      * `next()` function will execute either the next handler in the chain or the waterfall step
      * itself.  This handler lets a developer skip steps and process the args being passed to

--- a/Node/core/lib/dialogs/WaterfallDialog.js
+++ b/Node/core/lib/dialogs/WaterfallDialog.js
@@ -26,7 +26,15 @@ var WaterfallDialog = (function (_super) {
         return _this;
     }
     WaterfallDialog.prototype.begin = function (session, args) {
-        this.doStep(session, 0, args);
+        var _this = this;
+        if (this._onBeforeBegin) {
+            this._onBeforeBegin(session, args, function (args) {
+                _this.doStep(session, 0, args);
+            });
+        }
+        else {
+            this.doStep(session, 0, args);
+        }
     };
     WaterfallDialog.prototype.replyReceived = function (session, recognizeResult) {
         this.doStep(session, 0, recognizeResult.args);
@@ -44,6 +52,10 @@ var WaterfallDialog = (function (_super) {
                 break;
         }
         this.doStep(session, step, result);
+    };
+    WaterfallDialog.prototype.onBeforeBegin = function (handler) {
+        this._onBeforeBegin = handler;
+        return this;
     };
     WaterfallDialog.prototype.onBeforeStep = function (handler) {
         this._onBeforeStep.unshift(handler);


### PR DESCRIPTION
Here just a usage sample

```javascript
  import { Prompts, WaterfallDialog } from "botbuilder"

  const beforeBegin = async (session: Session, args: any, next: (args: any) => void) => {
    console.info("beforeBegin")

    next({ ...args, newArg: "newArg" })
  }

  const beforeStep = async (session: Session, step: number, args: any, next: (step: number, args: any) => void ) => {
    console.info("beforeStep")

    next(step, { ...args, anotherArg: "anotherArg" })
  }

  return new WaterfallDialog([
    async (session: Session) => {
      Prompts.confirm(session, "Do you want to continue?")
    }, async (session: Session) => {
      session.say("Ok")
    },
  ]).onBeforeBegin(beforeBegin).onBeforeStep(beforeStep)
```