### PR TITLE
Allow DictionaryBotData to work

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/BotData.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/ConnectorEx/BotData.cs
@@ -552,9 +552,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
                 botData.Data = this.MakeData();
                 await this.botDataStore.SaveAsync(botDataKey, botStoreType, botData, cancellationToken);
             }
-            return this.WrapData((T)botData.Data);
-        }
 
+            T data;
+            if (botData.Data is JObject)
+            {
+                data = ((JObject) botData.Data).ToObject<T>();
+            }
+            else
+            {
+                data = (T) botData.Data;
+            }
+
+            return this.WrapData(data);
+        }
+        
         private void CheckNull(string name, IBotDataBag value)
         {
             if (value == null)


### PR DESCRIPTION
Because of serialising a JSON object to a .net object creates a JObject, we cannot expect botData.Data to be T.  Hence deal with it being a JObject.

Note we need to allow for `botData.Data` being either `T` or `JObject` because in the case that it is returned from the `CachingBotDataStore` it will be a `T` while if it's been loaded from a persistent store where it was serialised it will be a `JObject`.  

This is a fix for https://github.com/Microsoft/BotBuilder/issues/4128