### PR TITLE
DialogTasks: fix NullReferenceException

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/Dialogs/DialogTaskManager.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Dialogs/DialogTaskManager.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
         {
             if (value == null)
             {
-                throw new InvalidOperationException($"\"{name}\" cannot be null. Probably forgot to call {nameof(IDialogTaskManager.LoadDialogTasks)}() first.");
+                throw new InvalidOperationException($"\"{name}\" cannot be null. Probably forgot to call {nameof(IDialogTaskManager)}.{nameof(IDialogTaskManager.LoadDialogTasks)}() first.");
             }
             return value;
         }

--- a/CSharp/Library/Microsoft.Bot.Builder/Dialogs/DialogTaskManager.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Dialogs/DialogTaskManager.cs
@@ -1,4 +1,4 @@
-﻿// 
+// 
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 // 
@@ -125,7 +125,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Internals
 
         IReadOnlyList<IDialogTask> IDialogTasks.DialogTasks
         {
-            get { return this.dialogTasks; }
+            get { return CheckNull(nameof(this.dialogTasks), this.dialogTasks); }
+        }
+
+        private IReadOnlyList<IDialogTask> CheckNull(string name, IReadOnlyList<IDialogTask> value)
+        {
+            if (value == null)
+            {
+                throw new InvalidOperationException($"\"{name}\" cannot be null. Probably forgot to call {nameof(IDialogTaskManager.LoadDialogTasks)}() first.");
+            }
+            return value;
         }
 
         IDialogTask IDialogTasks.CreateDialogTask()


### PR DESCRIPTION
Fixed `NullReferenceException` when accessing `DialogTaskManager.DialogTasks` if forgot to call `LoadDialogTasks()` first. It's better to provide a meaningful `InvalidOperationException` when accessing this property and it is null

Came across this issue when trying to resolve a new instance of `DialogContext` with Autofac container using a nested lifetime scope. This triggers resolving an `IDialogStack`, which has this registration in `DialogModule.cs` at [this line](https://github.com/Microsoft/BotBuilder/blob/31048a2173313c81a2db47efce6a8a869b4ec284/CSharp/Library/Microsoft.Bot.Builder.Autofac/Dialogs/DialogModule.cs#L223):

`            builder.Register(c => c.Resolve<IDialogTaskManager>().DialogTasks[0])`

If `DialogTaskManager` is instantitated for the first time in current lifetime scope, `DialogTasks` will return `null` and applying the `[0]` expression will result in a `NullReferenceException`. 

The only information I had to understand what was going wrong, was the `NullReferenceException.StackTrace`, which only pointed to some unknown lambda expression inside of `DialogModule.Load()`. This doesn't give any clue. I was referencing a Nuget-package, so I couldn't debug without downloading all the source code and compiling it and referencing it in my project. 

So providing a meaningful exception will help others to resolve this issue faster, I hope.