### PR TITLE
Fix for unseekable stream + typo fix

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Connector.NetCore/Content/Microsoft.Bot.Connector.NetCore.XML
+++ b/CSharp/Library/Microsoft.Bot.Connector.NetCore/Content/Microsoft.Bot.Connector.NetCore.XML
@@ -5512,7 +5512,13 @@
             The channel data essentially allows a bot to have access to native functionality on a per channel basis.
             </remarks>
         </member>
-        <!-- Badly formed XML comment ignored for member "M:Microsoft.Bot.Connector.IActivity.GetChannelData``1" -->
+        <member name="M:Microsoft.Bot.Connector.IActivity.GetChannelData``1">
+            <summary>
+            Get the channel data as strongly typed object
+            </summary>
+            <typeparam name="TypeT"></typeparam>
+            <returns></returns>
+        </member>
         <member name="M:Microsoft.Bot.Connector.IActivity.TryGetChannelData``1(``0@)">
             <summary>
             Try to get the channeldata as a strongly typed object 

--- a/CSharp/Library/Microsoft.Bot.Connector.NetFramework/Content/Microsoft.Bot.Connector.xml
+++ b/CSharp/Library/Microsoft.Bot.Connector.NetFramework/Content/Microsoft.Bot.Connector.xml
@@ -5549,7 +5549,13 @@
             The channel data essentially allows a bot to have access to native functionality on a per channel basis.
             </remarks>
         </member>
-        <!-- Badly formed XML comment ignored for member "M:Microsoft.Bot.Connector.IActivity.GetChannelData``1" -->
+        <member name="M:Microsoft.Bot.Connector.IActivity.GetChannelData``1">
+            <summary>
+            Get the channel data as strongly typed object
+            </summary>
+            <typeparam name="TypeT"></typeparam>
+            <returns></returns>
+        </member>
         <member name="M:Microsoft.Bot.Connector.IActivity.TryGetChannelData``1(``0@)">
             <summary>
             Try to get the channeldata as a strongly typed object 

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/AttachmentsExtensions.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/ConnectorAPI/AttachmentsExtensions.cs
@@ -95,9 +95,8 @@ namespace Microsoft.Bot.Connector
             using (var _result = await operations.GetAttachmentWithHttpMessagesAsync(attachmentId, viewId, null, cancellationToken).ConfigureAwait(false))
             {
                 MemoryStream memoryStream = new MemoryStream();
-                byte[] buffer = new byte[_result.Body.Length];
-                await _result.Body.ReadAsync(buffer, 0, (int)_result.Body.Length).ConfigureAwait(false);
-                return buffer;
+                await _result.Body.CopyToAsync(memoryStream).ConfigureAwait(false);
+                return memoryStream.ToArray();
             }
         }
 

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/IActivity.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/IActivity.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Get the channel data as strongly typed object
         /// </summary>
-        /// <typeparatm name="TypeT"></typeparam>
+        /// <typeparam name="TypeT"></typeparam>
         /// <returns></returns>
         TypeT GetChannelData<TypeT>();
 


### PR DESCRIPTION
Attachments API test cases were failing because AttachmentsExtension was throwing unseekable stream.

Also, fixing a typo in a /// comment block (which is included in 2 other auto-generated files).