### PR TITLE
updated the LUIS TryFindEntity extension to only return an entity by …

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/Extensions.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/Extensions.cs
@@ -53,7 +53,16 @@ namespace Microsoft.Bot.Builder.Luis
         /// <returns>True if the entity was found, false otherwise.</returns>
         public static bool TryFindEntity(this LuisResult result, string type, out EntityRecommendation entity)
         {
-            entity = result.Entities?.FirstOrDefault(e => e.Type == type);
+            Func<EntityRecommendation, IList<EntityRecommendation>, bool> doesNotOverlapRange = (current, recommendations) =>
+            {
+                return recommendations.Where(r => current != r)
+                            .Any(r => r.StartIndex.HasValue && r.EndIndex.HasValue && current.StartIndex.HasValue && Enumerable.Range(r.StartIndex.Value, r.EndIndex.Value - r.StartIndex.Value + 1)
+                                        .Contains(current.StartIndex.Value));
+            };
+
+
+            // find the recommended entity that does not overlap start and end ranges with other result entities
+            entity = result.Entities?.Where(e => e.Type == type && doesNotOverlapRange(e, result.Entities)).FirstOrDefault();
             return entity != null;
         }
 


### PR DESCRIPTION
…type if its start index doesn't overlap with the start and end index of other LuisResult Entities.  I came across this issue when working with an intent that accepts both a date and number.  If the intent message is 'make a reservation tomorrow morning at 2 for 7 people', 7 being the trained 'number' in LUIS, the current TryFindEntity extension was pulling back '2', which was already considered part of the datetime entity.