### PR TITLE
Bugfix/handle empty stack

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/Fibers/Fiber.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Fibers/Fiber.cs
@@ -234,7 +234,11 @@ namespace Microsoft.Bot.Builder.Internals.Fibers
                 }
                 catch (Exception error)
                 {
-                    this.stack.Pop();
+                    if (this.stack.Count != 0)
+                    {
+                        this.stack.Pop();
+                    }
+
                     if (this.stack.Count == 0)
                     {
                         throw;

--- a/CSharp/Tests/Microsoft.Bot.Builder.Tests/FiberTests.cs
+++ b/CSharp/Tests/Microsoft.Bot.Builder.Tests/FiberTests.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(InvalidOperationException))]
+        [ExpectedException(typeof(InvalidNeedException))]
         public async Task Fiber_OneCall_ThenDone_Throws()
         {
             // arrange


### PR DESCRIPTION
Its known that often times "Stack is empty" exception is hiding the underlying exception. It will be helpful for bot developers if the original exception is bubbled up instead of “Stack is empty” InvalidOperationException.

Fix -> Implemented fix to not pop stack if it is not empty.

Issue -> I searched for existing issues and this one came close -> https://github.com/Microsoft/BotBuilder/issues/2411

