### PR TITLE
Moved v4 sdk line to v4 section as to make readme less confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # Bot Builder SDK 
 
-Bot Builder SDK v4 is the latest SDK for building bot applications. It is in **Preview** state. Production bots should continue to be developed using the **v3 SDK** - [csharp](CSharp), [node](Node).
-
 The Bot Builder SDK enables you to build bots that support different types of interactions with users. You can design conversations in your bot to be freeform. Your bot can also have more guided interactions where it provides the user choices or actions. The conversation can use simple text or more complex rich cards that contain text, images, and action buttons. You can add natural language interactions and questions and answers, which let your users interact with your bots in a natural way.
 
 ![Bot Framework](https://botframework.blob.core.windows.net/web/images/bot-framework.png)
 
-Bot Builder SDK v4 support four programming languages, each managed in a separate repo: .NET, JavaScript, Python, and java.
-
 The Bot Builder includes a set of [command line tools](https://github.com/microsoft/botbuilder-tools) to streamline end-to-end conversation centric development experience, and an [emulator](https://github.com/microsoft/botframework-emulator) for debugging your bot locally or in the cloud. 
 
 ## Get started with Bot Builder v4 (Preview) 
+
+*Bot Builder SDK v4 is the latest SDK for building bot applications. It is in **Preview** state. Production bots should continue to be developed using the **v3 SDK** - [csharp](CSharp), [node](Node).*
+
 It is easy to build your first Bot. You can create a bot with [Azure Bot Service](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-quickstart?view=azure-bot-service-4.0). Click [here](https://account.azure.com/signup) if you need a trial Azure subscription. 
 
 You can create a bot with Bot Builder SDK using your favorite language: 


### PR DESCRIPTION
The current README reads as if this is the v4 repo by mentioning it first. I've received feedback (and agree) its confusing to developers who first access it. 

I moved the line regarding the v4 sdk being in preview to under the v4 heading. In addition I removed the duplicate line 'program in your favorite language' from the intro section as we already have information about it under the v4 heading. 