### PR TITLE
Accent insensitive terms

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/FormFlow/MessageActivityHelper.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/FormFlow/MessageActivityHelper.cs
@@ -32,6 +32,9 @@
 //
 
 using Microsoft.Bot.Connector;
+using System.Globalization;
+using System.Linq;
+using System.Text;
 
 namespace Microsoft.Bot.Builder.FormFlow.Advanced
 {
@@ -61,6 +64,16 @@ namespace Microsoft.Bot.Builder.FormFlow.Advanced
                 Type = ActivityTypes.Message,
                 Text = text
             };
+        }
+
+        internal static string RemoveDiacritics(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+                return text;
+
+            text = text.Normalize(NormalizationForm.FormD);
+            var chars = text.Where(c => CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark).ToArray();
+            return new string(chars).Normalize(NormalizationForm.FormC);
         }
     }
 }

--- a/CSharp/Library/Microsoft.Bot.Builder/FormFlow/Recognize.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/FormFlow/Recognize.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Bot.Builder.FormFlow.Advanced
             {
                 yield return new TermMatch(0, inputText.Length, 1.0, defaultValue);
             }
-
+            inputText = MessageActivityHelper.RemoveDiacritics(inputText);
             foreach (var expression in _expressions)
             {
                 double maxWords = expression.MaxWords;
@@ -244,7 +244,7 @@ namespace Microsoft.Bot.Builder.FormFlow.Advanced
         private const string NOMATCH = "__qqqq__";
         private int AddExpression(int n, object value, IEnumerable<string> terms, bool allowNumbers)
         {
-            var orderedTerms = (from term in terms orderby term.Length descending select term).ToArray();
+            var orderedTerms = (from term in terms orderby term.Length descending select MessageActivityHelper.RemoveDiacritics(term)).ToArray();
             var words = new StringBuilder();
             var first = true;
             int maxWords = 0;

--- a/CSharp/Library/Microsoft.Bot.Builder/MultilingualResources/Microsoft.Bot.Builder.el.xlf
+++ b/CSharp/Library/Microsoft.Bot.Builder/MultilingualResources/Microsoft.Bot.Builder.el.xlf
@@ -16,7 +16,7 @@
         </trans-unit>
         <trans-unit id="CommandBackTerms" translate="yes" xml:space="preserve">
           <source>backup;go back;back</source>
-          <target state="translated">backup;go back;back;πίσω;πισω;προηγουμενη;προηγούμενη;προηγουμενο;προηγούμενο</target>
+          <target state="translated">backup;go back;back;πισω;προηγουμενη;προηγουμενο</target>
         </trans-unit>
         <trans-unit id="CommandHelp" translate="yes" xml:space="preserve">
           <source>Help</source>
@@ -28,7 +28,7 @@
         </trans-unit>
         <trans-unit id="CommandHelpTerms" translate="yes" xml:space="preserve">
           <source>help;choices;\?</source>
-          <target state="translated">help;choices;\?;βοήθεια;βοηθεια</target>
+          <target state="translated">help;choices;\?;βοηθεια</target>
         </trans-unit>
         <trans-unit id="CommandQuit" translate="yes" xml:space="preserve">
           <source>Quit</source>
@@ -40,7 +40,7 @@
         </trans-unit>
         <trans-unit id="CommandQuitTerms" translate="yes" xml:space="preserve">
           <source>quit;stop;finish;goodby?;good bye?;bye;ciao;adios;bye-bye;so long;cheers</source>
-          <target state="translated">quit;stop;finish;goodby?;good bye?;bye;ciao;adios;bye-bye;so long;cheers;άκυρο;ακύρωση;ακυρο;ακυρωση</target>
+          <target state="translated">quit;stop;finish;goodby?;good bye?;bye;ciao;adios;bye-bye;so long;cheers;ακυρο;ακυρωση</target>
         </trans-unit>
         <trans-unit id="CommandReset" translate="yes" xml:space="preserve">
           <source>Start over</source>
@@ -52,7 +52,7 @@
         </trans-unit>
         <trans-unit id="CommandResetTerms" translate="yes" xml:space="preserve">
           <source>start over;reset;clear</source>
-          <target state="translated">start over;reset;clear;πάμε ξανά;παμε ξανα;παμε ξανά;πάμε ξανα;ξανάρχισε;ξαναρχισε</target>
+          <target state="translated">start over;reset;clear;παμε ξανα;ξαναρχισε;παμε;ξανα</target>
         </trans-unit>
         <trans-unit id="CommandStatus" translate="yes" xml:space="preserve">
           <source>Status</source>
@@ -64,7 +64,7 @@
         </trans-unit>
         <trans-unit id="CommandStatusTerms" translate="yes" xml:space="preserve">
           <source>status;progress;so far;results</source>
-          <target state="translated">status;progress;so far;results;κατάσταση;κατασταση</target>
+          <target state="translated">status;progress;so far;results;κατασταση</target>
         </trans-unit>
         <trans-unit id="Confirmation" translate="yes" xml:space="preserve">
           <source>Confirmation</source>

--- a/CSharp/Library/Microsoft.Bot.Builder/Resource/Resources.el.resx
+++ b/CSharp/Library/Microsoft.Bot.Builder/Resource/Resources.el.resx
@@ -19,7 +19,7 @@
     <value>Προηγούμενη: Πίσω στην προηγούμενη ερώτηση.</value>
   </data>
   <data name="CommandBackTerms" xml:space="preserve">
-    <value>backup;go back;back;πίσω;πισω;προηγουμενη;προηγούμενη;προηγουμενο;προηγούμενο</value>
+    <value>backup;go back;back;πισω;προηγουμενη;προηγουμενο</value>
   </data>
   <data name="CommandHelp" xml:space="preserve">
     <value>Βοήθεια</value>
@@ -28,7 +28,7 @@
     <value>Βοήθεια: Εμφανίζει τον τύπο των απαντήσεων που μπορείτε να δώσετε.</value>
   </data>
   <data name="CommandHelpTerms" xml:space="preserve">
-    <value>help;choices;\?;βοήθεια;βοηθεια</value>
+    <value>help;choices;\?;βοηθεια</value>
   </data>
   <data name="CommandQuit" xml:space="preserve">
     <value>Ακύρωση</value>
@@ -37,7 +37,7 @@
     <value>Ακύρωση: Ακυρώση συμπλήρωσης της φόρμας</value>
   </data>
   <data name="CommandQuitTerms" xml:space="preserve">
-    <value>quit;stop;finish;goodby?;good bye?;bye;ciao;adios;bye-bye;so long;cheers;άκυρο;ακύρωση;ακυρο;ακυρωση</value>
+    <value>quit;stop;finish;goodby?;good bye?;bye;ciao;adios;bye-bye;so long;cheers;ακυρο;ακυρωση</value>
   </data>
   <data name="CommandReset" xml:space="preserve">
     <value>Ξανάρχισε</value>
@@ -46,7 +46,7 @@
     <value>Ξανάρχισε: Ξεκινά από την αρχή τη συμπλήρωση της φόρμας.  (Με προσυμπληρωμένες τις προηγούμενες επιλογές.)</value>
   </data>
   <data name="CommandResetTerms" xml:space="preserve">
-    <value>start over;reset;clear;πάμε ξανά;παμε ξανα;παμε ξανά;πάμε ξανα;ξανάρχισε;ξαναρχισε</value>
+    <value>start over;reset;clear;παμε ξανα;ξαναρχισε;παμε;ξανα</value>
   </data>
   <data name="CommandStatus" xml:space="preserve">
     <value>Κατάσταση</value>
@@ -55,7 +55,7 @@
     <value>Κατάσταση: Εμφανίζει την μέχρι τώρα πρόοδο στην συμπλήρωση της φόρμας.</value>
   </data>
   <data name="CommandStatusTerms" xml:space="preserve">
-    <value>status;progress;so far;results;κατάσταση;κατασταση</value>
+    <value>status;progress;so far;results;κατασταση</value>
   </data>
   <data name="Confirmation" xml:space="preserve">
     <value>Επιβεβαίωση</value>


### PR DESCRIPTION
This pull request is making form flow term matching to be accent insensitive. Since now term matching was case insensitive but that was not enough for languages that make use of accents (like Greek lang). As an example καλημέρα is a different term from καλημερα. By removing diacritics from the terms we can easily match both.
The code that is doing the actual work of removing diacritics from words, was found on [John Otander’s blog ](http://www.levibotelho.com/development/c-remove-diacritics-accents-from-a-string)
