### PR TITLE
Update PromptDialog.cs 

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/Dialogs/PromptDialog.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Dialogs/PromptDialog.cs
@@ -533,6 +533,16 @@ namespace Microsoft.Bot.Builder.Dialogs
             context.Call<string>(child, resume);
         }
 
+        /// <summary>   Prompt for a string. </summary>
+        /// <param name="context">  The context. </param>
+        /// <param name="resume">   Resume handler. </param>
+        /// <param name="promptOptions"> The options for the prompt, <see cref="IPromptOptions{T}"/>.</param>
+        public static void Text(IDialogContext context, ResumeAfter<string> resume, IPromptOptions<string> promptOptions)
+        {
+            var child = new PromptString(promptOptions);
+            context.Call<string>(child, resume);
+        }
+        
         /// <summary>   Ask a yes/no question. </summary>
         /// <param name="context">  The context. </param>
         /// <param name="resume">   Resume handler. </param>


### PR DESCRIPTION
Add  `PromptDialog.Text` that accepts `IPromptOptions`.  This is important because on the Cortana channel you cannot have cortana speak the prompt currently.  This is available on other prompts, but not `PromptDialog.Text`.  [There was already a `PromptString` constructor for this](https://github.com/Microsoft/BotBuilder/blob/54d4cf56ef9881d6d8240bb8254c83f427924e6a/CSharp/Library/Microsoft.Bot.Builder/Dialogs/PromptDialog.cs#L682).  In the Node Sdk this is already possible out of the box.  In .Net we would have to inherit from `PromptDialog` like this:

```cs
    public class PromptDialogTextSpeak:PromptDialog
    {
        public static void Text(IDialogContext context, ResumeAfter<string> resume, IPromptOptions<string> promptOptions)
        {
            var child = new PromptString(promptOptions);
            context.Call<string>(child, resume);
        }
    }
```