### PR TITLE
Greek "No" prompt capitalization fix

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/MultilingualResources/Microsoft.Bot.Builder.el.xlf
+++ b/CSharp/Library/Microsoft.Bot.Builder/MultilingualResources/Microsoft.Bot.Builder.el.xlf
@@ -110,7 +110,7 @@
         </trans-unit>
         <trans-unit id="MatchNo" translate="yes" xml:space="preserve">
           <source>No;n;nope;2</source>
-          <target state="translated">όχι;ο;νο;2;no;No;οχι</target>
+          <target state="translated">Όχι;ο;νο;2;no;No;οχι</target>
         </trans-unit>
         <trans-unit id="MatchNoPreference" translate="yes" xml:space="preserve">
           <source>No Preference;no;none;I don'?t care</source>

--- a/CSharp/Library/Microsoft.Bot.Builder/Resource/Resources.el.resx
+++ b/CSharp/Library/Microsoft.Bot.Builder/Resource/Resources.el.resx
@@ -76,7 +76,7 @@
     <value>Προεπιλογή ('π');προεπιλογή;π;προεπιλογη</value>
   </data>
   <data name="MatchNo" xml:space="preserve">
-    <value>όχι;ο;νο;2;no;No;οχι</value>
+    <value>Όχι;ο;νο;2;no;No;οχι</value>
   </data>
   <data name="MatchNoPreference" xml:space="preserve">
     <value>Καμία επιλογή;όχι;καμία;οχι;τίποτα;καμια;τιποτα;δε με νοιάζει;δε με νοιαζει;αδιαφορο;αδιάφορο</value>


### PR DESCRIPTION
The resource key for the 'No' in greek language should be in capital.