### PR TITLE
Typo fix in ICardAction

### DIFF
--- a/Node/core/lib/botbuilder.d.ts
+++ b/Node/core/lib/botbuilder.d.ts
@@ -555,7 +555,7 @@ export interface ICardAction {
     text?: string;
 
     /** (Optional) text to display in the chat feed if the button is clicked. */
-    diplayText?: string;
+    displayText?: string;
 }
 
 /** Implemented by classes that can be converted into a card action. */


### PR DESCRIPTION
This typographical error prevents the use of the ICardAction literal instead of using the builder on TypeScript