### PR TITLE
Set all fields to null on 'reset' command in formflow

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/FormFlow/FormDialog.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/FormFlow/FormDialog.cs
@@ -766,7 +766,12 @@ namespace Microsoft.Bot.Builder.FormFlow
                     break;
                 case StepDirection.Reset:
                     _formState.Reset();
-                    // Because we redo phase they can go through everything again but with defaults.
+                    foreach (var step in _form.Steps)
+                    {
+                        if (step.Type == StepType.Field) {
+                            step.Field.SetValue(_state, null);
+                        }
+                    }
                     found = true;
                     break;
             }


### PR DESCRIPTION
Tested this with the formflowbot locally without issue, this code only runs when the "reset" command is given by a user and only resets steps marked as 'field' within a form, this results in the desired functionality for "reset" where all fields are reprompted to the user from the start.

Previously when a 'reset' command was issued the bot would reset the formState but leave the internal state alone, meaning that the values entered into it would still persist. This was meant for them to act as default values for the form, but when the first field was reprompted and an input was entered the other states would evaluate to "completed" due to the "skipstep" function. This fix avoids that by just setting all fields back to null (their original value) when reset is issued.