### PR TITLE
Revert "Directory.Build.props removed. (#4856)"

### DIFF
--- a/CSharp/Directory.Build.props
+++ b/CSharp/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+
+  <PropertyGroup>
+    <Version Condition=" '$(PackageVersion)' == '' ">3.15.3.0-local</Version>
+    <Version Condition=" '$(PackageVersion)' != '' ">$(PackageVersion)</Version>
+    <PackageVersion Condition=" '$(PackageVersion)' == '' ">3.15.3.0-local</PackageVersion>
+    <PackageVersion Condition=" '$(PackageVersion)' != '' ">$(PackageVersion)</PackageVersion>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This reverts commit e22a58e51ed37b071ca8736086dc1bade366037b.

When I merged that commit, it broke versioning for the botbuilder-v3-dotnet-daily packages. So reverting it.

Versioning is controlled by altering the value of the variable VersionRoot in the builds.