### PR TITLE
Add forwardDate and locale options to IPromptRecognizeTimesOptions

### DIFF
--- a/Node/core/lib/RemoteSessionLogger.js
+++ b/Node/core/lib/RemoteSessionLogger.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/Session.js
+++ b/Node/core/lib/Session.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/bots/Library.js
+++ b/Node/core/lib/bots/Library.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/bots/UniversalBot.js
+++ b/Node/core/lib/bots/UniversalBot.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/cards/AnimationCard.js
+++ b/Node/core/lib/cards/AnimationCard.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/cards/AudioCard.js
+++ b/Node/core/lib/cards/AudioCard.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/cards/HeroCard.js
+++ b/Node/core/lib/cards/HeroCard.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/cards/MediaCard.js
+++ b/Node/core/lib/cards/MediaCard.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/cards/ThumbnailCard.js
+++ b/Node/core/lib/cards/ThumbnailCard.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/cards/VideoCard.js
+++ b/Node/core/lib/cards/VideoCard.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/deprecated/CommandDialog.js
+++ b/Node/core/lib/deprecated/CommandDialog.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/deprecated/LegacyPrompts.js
+++ b/Node/core/lib/deprecated/LegacyPrompts.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }
@@ -63,7 +66,7 @@ var SimplePromptRecognizer = (function () {
                 }
                 break;
             case Prompt_1.PromptType.time:
-                var entity = EntityRecognizer_1.EntityRecognizer.recognizeTime(text, args.refDate ? new Date(args.refDate) : null);
+                var entity = EntityRecognizer_1.EntityRecognizer.recognizeTime(text);
                 if (entity) {
                     score = entity.entity.length / text.length;
                     response = entity;

--- a/Node/core/lib/deprecated/LuisDialog.js
+++ b/Node/core/lib/deprecated/LuisDialog.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/dialogs/Dialog.js
+++ b/Node/core/lib/dialogs/Dialog.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/dialogs/EntityRecognizer.js
+++ b/Node/core/lib/dialogs/EntityRecognizer.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var utils = require("../utils");
-var chrono = require("chrono-node");
+var chrono = require('chrono-node');
 var consts = require("../consts");
 var EntityRecognizer = (function () {
     function EntityRecognizer() {
@@ -78,10 +78,20 @@ var EntityRecognizer = (function () {
         }
         return resolvedDate;
     };
-    EntityRecognizer.recognizeTime = function (utterance, refDate) {
+    EntityRecognizer.recognizeTime = function (utterance, options) {
         var response;
         try {
-            var results = chrono.parse(utterance, refDate);
+            var refDate = options.refDate ? new Date(options.refDate) : null;
+            var forwardDate = options.forwardDate || null;
+            var locale = options.locale || null;
+            var chronoSupportedLocales = ["de", "en", "es", "fr", "ja", "zh"];
+            var results;
+            if (!locale || chronoSupportedLocales.indexOf(locale) === -1) {
+                results = chrono.parse(utterance, refDate, { forwardDate: forwardDate });
+            }
+            else {
+                results = chrono[locale].parse(utterance, refDate, { forwardDate: forwardDate });
+            }
             if (results && results.length > 0) {
                 var duration = results[0];
                 response = {

--- a/Node/core/lib/dialogs/IntentDialog.js
+++ b/Node/core/lib/dialogs/IntentDialog.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/dialogs/IntentRecognizerSet.js
+++ b/Node/core/lib/dialogs/IntentRecognizerSet.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/dialogs/LocalizedRegExpRecognizer.js
+++ b/Node/core/lib/dialogs/LocalizedRegExpRecognizer.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/dialogs/LuisRecognizer.js
+++ b/Node/core/lib/dialogs/LuisRecognizer.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/dialogs/Prompt.js
+++ b/Node/core/lib/dialogs/Prompt.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/dialogs/PromptAttachment.js
+++ b/Node/core/lib/dialogs/PromptAttachment.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/dialogs/PromptChoice.js
+++ b/Node/core/lib/dialogs/PromptChoice.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/dialogs/PromptConfirm.js
+++ b/Node/core/lib/dialogs/PromptConfirm.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/dialogs/PromptNumber.js
+++ b/Node/core/lib/dialogs/PromptNumber.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/dialogs/PromptRecognizers.js
+++ b/Node/core/lib/dialogs/PromptRecognizers.js
@@ -137,10 +137,9 @@ var PromptRecognizers = (function () {
     };
     PromptRecognizers.recognizeTimes = function (context, options) {
         options = options || {};
-        var refData = options.refDate ? new Date(options.refDate) : null;
         var entities = [];
         var utterance = context.message.text ? context.message.text.trim() : '';
-        var entity = EntityRecognizer_1.EntityRecognizer.recognizeTime(utterance, refData);
+        var entity = EntityRecognizer_1.EntityRecognizer.recognizeTime(utterance, options);
         if (entity) {
             entity.score = PromptRecognizers.calculateScore(utterance, entity.entity);
             entities.push(entity);

--- a/Node/core/lib/dialogs/PromptText.js
+++ b/Node/core/lib/dialogs/PromptText.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/dialogs/PromptTime.js
+++ b/Node/core/lib/dialogs/PromptTime.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/dialogs/RegExpRecognizer.js
+++ b/Node/core/lib/dialogs/RegExpRecognizer.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/dialogs/SimpleDialog.js
+++ b/Node/core/lib/dialogs/SimpleDialog.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/lib/dialogs/WaterfallDialog.js
+++ b/Node/core/lib/dialogs/WaterfallDialog.js
@@ -1,8 +1,11 @@
 "use strict";
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }

--- a/Node/core/src/deprecated/LegacyPrompts.ts
+++ b/Node/core/src/deprecated/LegacyPrompts.ts
@@ -120,7 +120,8 @@ export class SimplePromptRecognizer implements IPromptRecognizer {
                 }
                 break;
             case PromptType.time:
-                var entity = EntityRecognizer.recognizeTime(text, args.refDate ? new Date(args.refDate) : null);
+                // I deleted the refDate arg
+                var entity = EntityRecognizer.recognizeTime(text);
                 if (entity) {
                     score = entity.entity.length / text.length;
                     response = entity;

--- a/Node/core/src/dialogs/EntityRecognizer.ts
+++ b/Node/core/src/dialogs/EntityRecognizer.ts
@@ -31,9 +31,11 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 import { IRecognizeContext } from './IntentRecognizer';
+import { IPromptRecognizeTimesOptions } from './PromptRecognizers';
 import * as utils from '../utils';
-import * as sprintf from 'sprintf-js';
-import * as chrono from 'chrono-node';
+// didn't work
+// import * as chrono from 'chrono-node';
+const chrono = require('chrono-node');
 import * as consts from '../consts';
 
 interface ILuisDateTimeEntity extends IEntity<string> {
@@ -144,10 +146,21 @@ export class EntityRecognizer {
         return resolvedDate;
     }
 
-    static recognizeTime(utterance: string, refDate?: Date): IChronoDuration {
+    static recognizeTime(utterance: string, options?: IPromptRecognizeTimesOptions): IChronoDuration {
         var response: IChronoDuration;
         try {
-            var results = chrono.parse(utterance, refDate);
+            const refDate = options.refDate ? new Date(options.refDate) : null;
+            const forwardDate = options.forwardDate || null;
+            const locale = options.locale || null;
+            // I am thinking of adding a function to chrono-node
+            // that returns its supported locales
+            const chronoSupportedLocales = ["de", "en", "es", "fr", "ja", "zh"];
+            var results;
+            if (!locale || chronoSupportedLocales.indexOf(locale) === -1) {
+                results = chrono.parse(utterance, refDate, { forwardDate });
+            } else {
+                results = chrono[locale].parse(utterance, refDate, { forwardDate });
+            }
             if (results && results.length > 0) {
                 var duration = results[0];
                 response = {

--- a/Node/core/src/dialogs/PromptRecognizers.ts
+++ b/Node/core/src/dialogs/PromptRecognizers.ts
@@ -54,6 +54,12 @@ export interface IPromptRecognizeNumbersOptions {
 export interface IPromptRecognizeTimesOptions {
     /** (Optional) Reference date for releative times. */
     refDate?: number;
+
+    /** (Optional) To assume the results should happen after the reference date. */
+    forwardDate?: boolean;
+
+    /** (Optional) Predefined locale to increase parsing accuracy. */
+    locale?: string;
 }
 
 export interface IPromptRecognizeValuesOptions {
@@ -270,10 +276,9 @@ export class PromptRecognizers {
     /** Recognizes a time or duration mentioned in an utterance. */
     static recognizeTimes(context: IRecognizeContext, options?: IPromptRecognizeTimesOptions): IEntity<string>[]  {
         options = options || {};
-        let refData = options.refDate ? new Date(options.refDate) : null;
         let entities: IEntity<string>[] = [];
         const utterance = context.message.text ? context.message.text.trim() : '';
-        let entity = EntityRecognizer.recognizeTime(utterance, refData);
+        let entity = EntityRecognizer.recognizeTime(utterance, options);
         if (entity) {
             entity.score = PromptRecognizers.calculateScore(utterance, entity.entity);
             entities.push(entity);

--- a/Node/core/tests/timePrompts.js
+++ b/Node/core/tests/timePrompts.js
@@ -1,0 +1,52 @@
+var assert = require('assert');
+var builder = require('../');
+
+describe('timePrompts', function () {
+    this.timeout(5000);
+
+    it('should recognize weekdays in german', function (done) {
+        var connector = new builder.ConsoleConnector();
+        var bot = new builder.UniversalBot(connector);
+        bot.dialog('/', [
+            function (session) {
+                assert(session.message.text == 'start');
+                builder.Prompts.time(session, 'enter date', { refDate: '2018-08-22', locale: 'de' });
+            },
+            function (session, results) {
+                const date = builder.EntityRecognizer.resolveTime([results.response]);
+                assert(date.getFullYear() === 2018);
+                assert(date.getMonth() + 1 === 8);
+                assert(date.getDate() === 20);
+                done();
+            },
+        ]);
+        bot.on('send', function (message) {
+            assert(message.text == 'enter date');
+            connector.processMessage('Montag');
+        });
+        connector.processMessage('start');
+    });
+
+    it('should recognize weekdays in german (forward date)', function (done) {
+        var connector = new builder.ConsoleConnector();
+        var bot = new builder.UniversalBot(connector);
+        bot.dialog('/', [
+            function (session) {
+                assert(session.message.text == 'start');
+                builder.Prompts.time(session, 'enter date', { refDate: '2018-08-22', forwardDate: true, locale: 'de' });
+            },
+            function (session, results) {
+                const date = builder.EntityRecognizer.resolveTime([results.response]);
+                assert(date.getFullYear() === 2018);
+                assert(date.getMonth() + 1 === 8);
+                assert(date.getDate() === 27);
+                done();
+            },
+        ]);
+        bot.on('send', function (message) {
+            assert(message.text == 'enter date');
+            connector.processMessage('Montag');
+        });
+        connector.processMessage('start');
+    });
+});


### PR DESCRIPTION
builder.Prompts.time doesn't recognize German dates like 07.11 (7th of November) or Morgen (tomorrow)
I have added a locale option to IPromptRecognizeTimesOptions in order to use a localized version of chrono in order to improve accuracy of parsing the dates.

Issue #2409 had the same problem but opted to use builder.Prompts.text and parse the utterance using another library. A solution i couldn't follow.

Also, I added a forwardDate option too because i think it might come handy in some cases.

Two issues I have encountered when making the changes are:
First, the transpiler didn't work unless I changed the import of chrono-node from this
`import * as chrono from 'chrono-node';`
to this
`const chrono = require('chrono-node');`
because I am using this statement
`results = chrono[locale].parse(utterance, refDate, { forwardDate });`
Second, after transpiling from TypeScript to JavaScript, all JS files had changes I didn't make in
`var extendStatics`